### PR TITLE
newApprovers/v1/1_000

### DIFF
--- a/jsonschema/apis/Approvers_v1_000.json
+++ b/jsonschema/apis/Approvers_v1_000.json
@@ -3,7 +3,7 @@
   "servers": [
     {
         "description": "API para Cadastro de Aprovadores (Approvers) TOTVS.",
-        "url": "http://{serverUrl}:{serverHttpPort}/api/suppy/v1",
+        "url": "http://{serverUrl}:{serverHttpPort}/api/supply/v1",
         "variables":{      
             "serverUrl":{
                 "default":"localhost"

--- a/jsonschema/schemas/Approvers_2_000.json
+++ b/jsonschema/schemas/Approvers_2_000.json
@@ -648,14 +648,14 @@
 					"x-totvs":[                                    
 						{
 							"product":"datasul",
-							"field":"mla-usuar-aprov.cod-lotacao",
+							"field":"mla-usuar-aprov.e-mail",
 							"description":"",
 							"required":true,
 							"type":"char",
 							"length":80,
 							"available": true,
 							"canUpdate": false,
-							"note":"A lotação informada deverá estar previamente cadastrada nas Lotações da Aprovação (MLA0123) para a Empresa o qual o Estabelecimento do Aprovador está vinculado."
+							"note":""
 						}
 					]
 				}


### PR DESCRIPTION
Correção de informação documentacional: URL do arquivo openapi (de suppy >> supply) e informação do campo de e-mail do aprovador (arquivo de schema).