### PR TITLE
Ajustes APIs Healthcare

### DIFF
--- a/jsonschema/apis/AccommodationType_v1_000.json
+++ b/jsonschema/apis/AccommodationType_v1_000.json
@@ -44,7 +44,7 @@
     },
 
     "paths": {
-        "/accommodationType/{code}": {
+        "/accommodationTypes/{code}": {
           "get": {
             "tags": [
               "AccommodationType"
@@ -195,7 +195,7 @@
             }
           }
         },
-        "/accommodationType": {
+        "/accommodationTypes": {
           "get": {
             "tags": [
               "AccommodationType"

--- a/jsonschema/apis/CopaymentType_v1_000.json
+++ b/jsonschema/apis/CopaymentType_v1_000.json
@@ -44,7 +44,7 @@
     },
 
     "paths": {
-        "/copaymentType/{code}": {
+        "/copaymentTypes/{code}": {
           "get": {
             "tags": [
               "CopaymentType"
@@ -195,7 +195,7 @@
             }
           }
         },
-        "/copaymentType": {
+        "/copaymentTypes": {
           "get": {
             "tags": [
               "CopaymentType"

--- a/jsonschema/apis/CoverageModuleGroup_v1_000.json
+++ b/jsonschema/apis/CoverageModuleGroup_v1_000.json
@@ -44,7 +44,7 @@
     },
 
     "paths": {
-        "/coverageModuleGroup/{code}": {
+        "/coverageModuleGroups/{code}": {
           "get": {
             "tags": [
               "CoverageModuleGroup"
@@ -195,7 +195,7 @@
             }
           }
         },
-        "/coverageModuleGroup": {
+        "/coverageModuleGroups": {
           "get": {
             "tags": [
               "CoverageModuleGroup"

--- a/jsonschema/apis/CoverageModule_v1_000.json
+++ b/jsonschema/apis/CoverageModule_v1_000.json
@@ -44,7 +44,7 @@
     },
 
     "paths": {
-        "/coverageModule/{code}": {
+        "/coverageModules/{code}": {
           "get": {
             "tags": [
               "CoverageModule"
@@ -195,7 +195,7 @@
             }
           }
         },
-        "/coverageModule": {
+        "/coverageModules": {
           "get": {
             "tags": [
               "CoverageModule"

--- a/jsonschema/apis/HealthCondition_v1_000.json
+++ b/jsonschema/apis/HealthCondition_v1_000.json
@@ -44,7 +44,7 @@
     },
 
     "paths": {
-        "/healthCondition/{code}": {
+        "/healthConditions/{code}": {
           "get": {
             "tags": [
               "HealthCondition"
@@ -195,7 +195,7 @@
             }
           }
         },
-        "/healthCondition": {
+        "/healthConditions": {
           "get": {
             "tags": [
               "HealthCondition"

--- a/jsonschema/apis/HealthProviderGroup_v1_000.json
+++ b/jsonschema/apis/HealthProviderGroup_v1_000.json
@@ -44,7 +44,7 @@
     },
 
     "paths": {
-        "/healthProviderGroup/{code}": {
+        "/healthProviderGroups/{code}": {
           "get": {
             "tags": [
               "HealthProviderGroup"
@@ -195,7 +195,7 @@
             }
           }
         },
-        "/healthProviderGroup": {
+        "/healthProviderGroups": {
           "get": {
             "tags": [
               "HealthProviderGroup"

--- a/jsonschema/apis/HealthProviderRelationType_v1_000.json
+++ b/jsonschema/apis/HealthProviderRelationType_v1_000.json
@@ -44,7 +44,7 @@
     },
 
     "paths": {
-        "/healthProviderRelationType/{code}": {
+        "/healthProviderRelationTypes/{code}": {
           "get": {
             "tags": [
               "HealthProviderRelationType"
@@ -195,7 +195,7 @@
             }
           }
         },
-        "/healthProviderRelationType": {
+        "/healthProviderRelationTypes": {
           "get": {
             "tags": [
               "HealthProviderRelationType"

--- a/jsonschema/apis/IndexIncreaseType_v1_000.json
+++ b/jsonschema/apis/IndexIncreaseType_v1_000.json
@@ -44,7 +44,7 @@
     },
 
     "paths": {
-        "/indexIncreaseType/{code}": {
+        "/indexIncreaseTypes/{code}": {
           "get": {
             "tags": [
               "IndexIncreaseType"
@@ -195,7 +195,7 @@
             }
           }
         },
-        "/indexIncreaseType": {
+        "/indexIncreaseTypes": {
           "get": {
             "tags": [
               "IndexIncreaseType"

--- a/jsonschema/apis/MedicalSpecialty_v1_000.json
+++ b/jsonschema/apis/MedicalSpecialty_v1_000.json
@@ -44,7 +44,7 @@
     },
 
     "paths": {
-        "/medicalSpecialty/{code}": {
+        "/medicalSpecialties/{code}": {
           "get": {
             "tags": [
               "MedicalSpecialty"
@@ -195,7 +195,7 @@
             }
           }
         },
-        "/medicalSpecialty": {
+        "/medicalSpecialties": {
           "get": {
             "tags": [
               "MedicalSpecialty"

--- a/jsonschema/apis/MedicineBranch_v1_000.json
+++ b/jsonschema/apis/MedicineBranch_v1_000.json
@@ -44,7 +44,7 @@
     },
 
     "paths": {
-        "/medicineBranch/{code}": {
+        "/medicineBranches/{code}": {
           "get": {
             "tags": [
               "MedicineBranch"
@@ -195,7 +195,7 @@
             }
           }
         },
-        "/medicineBranch": {
+        "/medicineBranches": {
           "get": {
             "tags": [
               "MedicineBranch"

--- a/jsonschema/apis/ProposalType_v1_000.json
+++ b/jsonschema/apis/ProposalType_v1_000.json
@@ -44,7 +44,7 @@
     },
 
     "paths": {
-        "/proposalType/{code}": {
+        "/proposalTypes/{code}": {
           "get": {
             "tags": [
               "ProposalType"
@@ -195,7 +195,7 @@
             }
           }
         },
-        "/proposalType": {
+        "/proposalTypes": {
           "get": {
             "tags": [
               "ProposalType"

--- a/jsonschema/apis/SecondCopyReason_v1_000.json
+++ b/jsonschema/apis/SecondCopyReason_v1_000.json
@@ -44,7 +44,7 @@
     },
 
     "paths": {
-        "/secondCopyReason/{code}": {
+        "/secondCopyReasons/{code}": {
           "get": {
             "tags": [
               "SecondCopyReason"
@@ -195,7 +195,7 @@
             }
           }
         },
-        "/secondCopyReason": {
+        "/secondCopyReasons": {
           "get": {
             "tags": [
               "SecondCopyReason"

--- a/jsonschema/apis/TextPattern_v1_000.json
+++ b/jsonschema/apis/TextPattern_v1_000.json
@@ -44,7 +44,7 @@
     },
 
     "paths": {
-        "/textPattern/{code}": {
+        "/textPatterns/{code}": {
           "get": {
             "tags": [
               "TextPattern"
@@ -195,7 +195,7 @@
             }
           }
         },
-        "/textPattern": {
+        "/textPatterns": {
           "get": {
             "tags": [
               "TextPattern"


### PR DESCRIPTION
O nome do recurso destas mensagens estava no singular, foi ajustado para o plural.
Foi mantida na versão pois as APIs envolvidas ainda não foram publicadas.