### PR TITLE
UnitMeasurementConversion/2_001

### DIFF
--- a/jsonschema/schemas/UnitMeasurementConversion_2_001.json
+++ b/jsonschema/schemas/UnitMeasurementConversion_2_001.json
@@ -540,8 +540,13 @@
                         },
                         {
                             "product": "logix",
-                            "available": "false",
-                            "canUpdate": "false"
+                            "available": "true",
+                            "canUpdate": "false",
+                            "field": "fat_conver.cod_uni_med_orig, fat_conver.cod_uni_med_dest",
+                            "length": "3",
+                            "note": "Unidade de Medida origem/Destino",
+                            "required": "true",
+                            "type": "varchar"
                         }
                     ]
                 },


### PR DESCRIPTION
Alterado o x-totvs do atributo "code" para o produto Logix, no #/definitions/Unit_of_Measurement