### PR TITLE
unitMeasurementConversions/v2

### DIFF
--- a/jsonschema/apis/UnitMeasurementConversion_v2_000.json
+++ b/jsonschema/apis/UnitMeasurementConversion_v2_000.json
@@ -444,7 +444,7 @@
 						"content": {
 							"application/json": {
 								"schema": {
-									"$ref": "https://raw.githubusercontent.com/totvs/ttalk-standard-message/master/jsonschema/schemas/UnitMeasurementConversion_2_001.json#/definitions/collectionConversionUnitMeasurement"
+									"$ref": "https://raw.githubusercontent.com/totvs/ttalk-standard-message/master/jsonschema/schemas/UnitMeasurementConversion_2_001.json#/definitions/conversion_of_Unit_of_Measurement"
 								}
 							}
 						}


### PR DESCRIPTION
Corrigindo no openAPI o que deve retornar ao dar status http code 200 do endpoint get /unitMeasurementConversions/{internalId}, para retornar um único item, identificado pelo pathParam internalId e não uma lista.