### PR TITLE
MRPBillOfMaterial/V1/1_000

### DIFF
--- a/jsonschema/apis/MRPBillOfMaterial_v1_000.json
+++ b/jsonschema/apis/MRPBillOfMaterial_v1_000.json
@@ -1,351 +1,479 @@
 {
-	"openapi": "3.0.1",
-	"servers": [
-		{
-			"description": "API para manipulação das Estruturas do MRP",
-			"url": "http://{serverUrl}:{serverHttpPort}/api/pcp/v1",
-			"variables": {
-				"serverUrl": {
-					"default": "localhost"
-				},
-				"serverHttpPort": {
-					"default": "8040"
-				}
-			}
-		}
-	],
-	"info": {
-		"description": "API para a entidade de Estruturas do MRP",
-		"version": "1.000",
-		"title": "Estruturas do MRP",
-		"x-totvs": {
-			"messageDocumentation": {
-				"name": "MRPBillOfMaterial",
-				"description": "Estruturas do MRP",
-				"segment": "Manufatura"
-			},
-			"productInformation": [
-				{
-					"product": "Protheus",
-					"contact": "robson.klug@totvs.com.br",
-					"description": "Cadastro de Estrutura do MRP",
-					"adapter": ""
-				}
-			]
-		}
-	},
-	"paths": {
-		"/billofmaterial": {
-			"post": {
-				"tags": [
-					"billofmaterial"
-				],
-				"summary": "Inclui ou atualiza uma ou mais estruturas do MRP",
-				"description": "",
-				"operationId": "postbillofmaterial",
-				"responses": {
-					"201": {
-						"description": "Operação realizada com sucesso",
-						"content": {
-							"application/json": {
-								"schema": {
-									"$ref": "https://raw.githubusercontent.com/totvs/ttalk-standard-message/master/jsonschema/schemas/MRPBillOfMaterial_1_000.json#/definitions/PagedMRPBillOfMaterial"
-								}
-							}
-						}
-					},
-					"207": {
-						"description": "Operação realizada parcialmente com sucesso",
-						"content": {
-							"application/json": {
-								"schema": {
-									"$ref": "https://raw.githubusercontent.com/totvs/ttalk-standard-message/master/jsonschema/schemas/MRPBillOfMaterial_1_000.json#/definitions/MRPBillOfMaterialMultiple"
-								}
-							}
-						}
-					},
-					"400": {
-						"description": "Erro no momento da Inclusão",
-						"content": {
-							"application/json": {
-								"schema": {
-									"$ref": "https://raw.githubusercontent.com/totvs/ttalk-standard-message/master/jsonschema/apis/types/totvsApiTypesBase.json#/definitions/ErrorModel"
-								}
-							}
-						}
-					},
-					"503": {
-						"description": "Servidor não conseguiu processar a requisição",
-						"content": {
-							"application/json": {
-								"schema": {
-									"$ref": "https://raw.githubusercontent.com/totvs/ttalk-standard-message/master/jsonschema/apis/types/totvsApiTypesBase.json#/definitions/ErrorModel"
-								}
-							}
-						}
-					}
-				},
-				"x-totvs": {
-					"productInformation": [
-						{
-							"product": "Protheus",
-							"available": true,
-							"note": "Este verbo está disponível com todos os parâmetros",
-							"minimalVersion": "12.1.27"
-						}
-					]
-				},
-				"requestBody": {
-					"content": {
-						"application/json": {
-							"schema": {
-								"$ref": "https://raw.githubusercontent.com/totvs/ttalk-standard-message/master/jsonschema/schemas/MRPBillOfMaterial_1_000.json#/definitions/ListOfMRPBillOfMaterial"
-							}
-						}
-					},
-					"description": "Objeto de estrutura do MRP que deve ser adicionado ou atualizado",
-					"required": true
-				}
-			},
-			"get": {
-				"tags": [
-					"billofmaterial"
-				],
-				"summary": "Lista de estruturas do MRP",
-				"description": "Retorna lista de estrutura do MRP",
-				"operationId": "getmrpbillofmaterial",
-				"parameters": [
-					{
-						"$ref": "https://raw.githubusercontent.com/totvs/ttalk-standard-message/master/jsonschema/apis/types/totvsApiTypesBase.json#/parameters/Order"
-					},
-					{
-						"$ref": "https://raw.githubusercontent.com/totvs/ttalk-standard-message/master/jsonschema/apis/types/totvsApiTypesBase.json#/parameters/Page"
-					},
-					{
-						"$ref": "https://raw.githubusercontent.com/totvs/ttalk-standard-message/master/jsonschema/apis/types/totvsApiTypesBase.json#/parameters/PageSize"
-					},
-					{
-						"$ref": "https://raw.githubusercontent.com/totvs/ttalk-standard-message/master/jsonschema/apis/types/totvsApiTypesBase.json#/parameters/Fields"
-					},
-					{
-						"name": "branchId",
-						"in": "query",
-						"description": "Código da filial",
-						"required": false,
-						"schema": {
-							"type": "string"
-						}
-					},
-					{
-						"name": "code",
-						"in": "query",
-						"description": "Código da estrutura",
-						"required": false,
-						"schema": {
-							"type": "string"
-						}
-					},
-					{
-						"name": "product",
-						"in": "query",
-						"description": "Código do produto PAI da estrutura",
-						"required": false,
-						"schema": {
-							"type": "string"
-						}
-					},
-					{
-						"name": "component",
-						"in": "query",
-						"description": "Código do componente da estrutura",
-						"required": false,
-						"schema": {
-							"type": "string"
-						}
-					},
-					{
-						"name": "sequence",
-						"in": "query",
-						"description": "Sequência do componente da estrutura",
-						"required": false,
-						"schema": {
-							"type": "string"
-						}
-					}
-				],
-				"responses": {
-					"200": {
-						"description": "Operação realizada com sucesso",
-						"content": {
-							"application/json": {
-								"schema": {
-									"$ref": "https://raw.githubusercontent.com/totvs/ttalk-standard-message/master/jsonschema/schemas/MRPBillOfMaterial_1_000.json#/definitions/PagedMRPBillOfMaterial"
-								}
-							}
-						}
-					},
-					"404": {
-						"description": "Estruturas do MRP não localizadas",
-						"content": {
-							"application/json": {
-								"schema": {
-									"$ref": "https://raw.githubusercontent.com/totvs/ttalk-standard-message/master/jsonschema/apis/types/totvsApiTypesBase.json#/definitions/ErrorModel"
-								}
-							}
-						}
-					}
-				},
-				"x-totvs": {
-					"productInformation": [
-						{
-							"product": "Protheus",
-							"available": true,
-							"note": "Este verbo está disponível com todos os parâmetros",
-							"minimalVersion": "12.1.27"
-						}
-					]
-				}
-			},
-			"delete": {
-				"tags": [
-					"billofmaterial"
-				],
-				"summary": "Remove uma ou mais estruturas do MRP",
-				"description": "Remove uma ou mais estruturas do MRP",
-				"operationId": "deletebillofmaterial",
-				"responses": {
-					"204": {
-						"description": "Operação realizada com sucesso"
-					},
-					"207": {
-						"description": "Operação realizada parcialmente com sucesso",
-						"content": {
-							"application/json": {
-								"schema": {
-									"$ref": "https://raw.githubusercontent.com/totvs/ttalk-standard-message/master/jsonschema/schemas/MRPBillOfMaterial_1_000.json#/definitions/MRPBillOfMaterialMultiple"
-								}
-							}
-						}
-					},
-					"400": {
-						"description": "Erro no momento da exclusão",
-						"content": {
-							"application/json": {
-								"schema": {
-									"$ref": "https://raw.githubusercontent.com/totvs/ttalk-standard-message/master/jsonschema/apis/types/totvsApiTypesBase.json#/definitions/ErrorModel"
-								}
-							}
-						}
-					},
-					"404": {
-						"description": "Estrutura do MRP não localizada na base",
-						"content": {
-							"application/json": {
-								"schema": {
-									"$ref": "https://raw.githubusercontent.com/totvs/ttalk-standard-message/master/jsonschema/apis/types/totvsApiTypesBase.json#/definitions/ErrorModel"
-								}
-							}
-						}
-					}
-				},
-				"requestBody": {
-					"content": {
-						"application/json": {
-							"schema": {
-								"$ref": "https://raw.githubusercontent.com/totvs/ttalk-standard-message/master/jsonschema/schemas/MRPBillOfMaterial_1_000.json#/definitions/ListOfMRPBillOfMaterial"
-							}
-						}
-					}
-				},
-				"x-totvs": {
-					"productInformation": [
-						{
-							"product": "Protheus",
-							"available": true,
-							"note": "Este verbo está disponível com todos os parâmetros",
-							"minimalVersion": "12.1.27"
-						}
-					]
-				}
-			}
-		},
-		"/billofmaterial/{branchId}/{product}": {
-			"get": {
-				"tags": [
-					"billofmaterial"
-				],
-				"summary": "Retorna uma estrutura do MRP",
-				"description": "Retorna uma estrutura do MRP",
-				"operationId": "getbillofmaterial",
-				"parameters": [
-					{
-						"$ref": "https://raw.githubusercontent.com/totvs/ttalk-standard-message/master/jsonschema/apis/types/totvsApiTypesBase.json#/parameters/Fields"
-					},
-					{
-						"$ref": "#/components/parameters/branchId"
-					},
-					{
-						"$ref": "#/components/parameters/product"
-					}
-				],
-				"responses": {
-					"200": {
-						"description": "Operação realizada com sucesso",
-						"content": {
-							"application/json": {
-								"schema": {
-									"$ref": "https://raw.githubusercontent.com/totvs/ttalk-standard-message/master/jsonschema/schemas/MRPBillOfMaterial_1_000.json#/definitions/MRPBillOfMaterial"
-								}
-							}
-						}
-					},
-					"404": {
-						"description": "Estrutura do MRP não localizada",
-						"content": {
-							"application/json": {
-								"schema": {
-									"$ref": "https://raw.githubusercontent.com/totvs/ttalk-standard-message/master/jsonschema/apis/types/totvsApiTypesBase.json#/definitions/ErrorModel"
-								}
-							}
-						}
-					}
-				},
-				"x-totvs": {
-					"productInformation": [
-						{
-							"product": "Protheus",
-							"available": true,
-							"note": "Este verbo está disponível com todos os parâmetros",
-							"minimalVersion": "12.1.27"
-						}
-					]
-				}
-			}
-		}
-	},
-	"components": {
-		"parameters": {
-			"branchId": {
-				"name": "branchId",
-				"in": "path",
-				"description": "Codigo da filial da demanda do MRP",
-				"required": true,
-				"schema": {
-					"type": "string",
-					"format": "char(2)"
-				}
-			},
-			"product": {
-				"name": "product",
-				"in": "path",
-				"description": "Codigo do produto PAI da estrutura do MRP",
-				"required": true,
-				"schema": {
-					"type": "string",
-					"format": "char(90)"
-				}
-			}
-		},
-		"schemas": {}
-	}
+  "openapi": "3.0.1",
+  "servers": [
+    {
+      "description": "API para manipulação das Estruturas do MRP",
+      "url": "http://{serverUrl}:{serverHttpPort}/api/pcp/v1",
+      "variables": {
+        "serverUrl": {
+          "default": "localhost"
+        },
+        "serverHttpPort": {
+          "default": "8040"
+        }
+      }
+    }
+  ],
+  "info": {
+    "description": "API para a entidade de Estruturas do MRP",
+    "version": "1.000",
+    "title": "Estruturas do MRP",
+    "x-totvs": {
+      "messageDocumentation": {
+        "name": "MRPBillOfMaterial",
+        "description": "Estruturas do MRP",
+        "segment": "Manufatura"
+      },
+      "productInformation": [
+        {
+          "product": "Protheus",
+          "contact": "robson.klug@totvs.com.br",
+          "description": "Cadastro de Estrutura do MRP",
+          "adapter": ""
+        }
+      ]
+    }
+  },
+  "paths": {
+    "/mrpbillofmaterial": {
+      "post": {
+        "tags": [
+          "mrpbillofmaterial"
+        ],
+        "summary": "Inclui ou atualiza uma ou mais estruturas do MRP",
+        "description": "",
+        "operationId": "postmrpbillofmaterial",
+        "responses": {
+          "201": {
+            "description": "Operação realizada com sucesso",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "https://raw.githubusercontent.com/totvs/ttalk-standard-message/MRPBillOfMaterial/V1/1_000/jsonschema/schemas/MRPBillOfMaterial_1_000.json#/definitions/PagedMRPBillOfMaterial"
+                }
+              }
+            }
+          },
+          "207": {
+            "description": "Operação realizada parcialmente com sucesso",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "https://raw.githubusercontent.com/totvs/ttalk-standard-message/MRPBillOfMaterial/V1/1_000/jsonschema/schemas/MRPBillOfMaterial_1_000.json#/definitions/MRPBillOfMaterialMultiple"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Erro no momento da Inclusão",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "https://raw.githubusercontent.com/totvs/ttalk-standard-message/master/jsonschema/apis/types/totvsApiTypesBase.json#/definitions/ErrorModel"
+                }
+              }
+            }
+          },
+          "503": {
+            "description": "Servidor não conseguiu processar a requisição",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "https://raw.githubusercontent.com/totvs/ttalk-standard-message/master/jsonschema/apis/types/totvsApiTypesBase.json#/definitions/ErrorModel"
+                }
+              }
+            }
+          }
+        },
+        "x-totvs": {
+          "productInformation": [
+            {
+              "product": "Protheus",
+              "available": true,
+              "note": "Este verbo está disponível com todos os parâmetros",
+              "minimalVersion": "12.1.27"
+            }
+          ]
+        },
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "https://raw.githubusercontent.com/totvs/ttalk-standard-message/MRPBillOfMaterial/V1/1_000/jsonschema/schemas/MRPBillOfMaterial_1_000.json#/definitions/ListOfMRPBillOfMaterial"
+              }
+            }
+          },
+          "description": "Objeto de estrutura do MRP que deve ser adicionado ou atualizado",
+          "required": true
+        }
+      },
+      "get": {
+        "tags": [
+          "mrpbillofmaterial"
+        ],
+        "summary": "Lista de estruturas do MRP",
+        "description": "Retorna lista de estrutura do MRP",
+        "operationId": "getmrpbillofmaterial",
+        "parameters": [
+          {
+            "$ref": "https://raw.githubusercontent.com/totvs/ttalk-standard-message/master/jsonschema/apis/types/totvsApiTypesBase.json#/parameters/Order"
+          },
+          {
+            "$ref": "https://raw.githubusercontent.com/totvs/ttalk-standard-message/master/jsonschema/apis/types/totvsApiTypesBase.json#/parameters/Page"
+          },
+          {
+            "$ref": "https://raw.githubusercontent.com/totvs/ttalk-standard-message/master/jsonschema/apis/types/totvsApiTypesBase.json#/parameters/PageSize"
+          },
+          {
+            "$ref": "https://raw.githubusercontent.com/totvs/ttalk-standard-message/master/jsonschema/apis/types/totvsApiTypesBase.json#/parameters/Fields"
+          },
+          {
+            "name": "branchId",
+            "in": "query",
+            "description": "Código da filial",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "code",
+            "in": "query",
+            "description": "Código da estrutura",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "product",
+            "in": "query",
+            "description": "Código do produto PAI da estrutura",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "component",
+            "in": "query",
+            "description": "Código do componente da estrutura",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "sequence",
+            "in": "query",
+            "description": "Sequência do componente da estrutura",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Operação realizada com sucesso",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "https://raw.githubusercontent.com/totvs/ttalk-standard-message/MRPBillOfMaterial/V1/1_000/jsonschema/schemas/MRPBillOfMaterial_1_000.json#/definitions/PagedMRPBillOfMaterial"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Estruturas do MRP não localizadas",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "https://raw.githubusercontent.com/totvs/ttalk-standard-message/master/jsonschema/apis/types/totvsApiTypesBase.json#/definitions/ErrorModel"
+                }
+              }
+            }
+          }
+        },
+        "x-totvs": {
+          "productInformation": [
+            {
+              "product": "Protheus",
+              "available": true,
+              "note": "Este verbo está disponível com todos os parâmetros",
+              "minimalVersion": "12.1.27"
+            }
+          ]
+        }
+      },
+      "delete": {
+        "tags": [
+          "mrpbillofmaterial"
+        ],
+        "summary": "Remove uma ou mais estruturas do MRP",
+        "description": "Remove uma ou mais estruturas do MRP",
+        "operationId": "deletemrpbillofmaterial",
+        "responses": {
+          "204": {
+            "description": "Operação realizada com sucesso"
+          },
+          "207": {
+            "description": "Operação realizada parcialmente com sucesso",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "https://raw.githubusercontent.com/totvs/ttalk-standard-message/MRPBillOfMaterial/V1/1_000/jsonschema/schemas/MRPBillOfMaterial_1_000.json#/definitions/MRPBillOfMaterialMultiple"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Erro no momento da exclusão",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "https://raw.githubusercontent.com/totvs/ttalk-standard-message/master/jsonschema/apis/types/totvsApiTypesBase.json#/definitions/ErrorModel"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Estrutura do MRP não localizada na base",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "https://raw.githubusercontent.com/totvs/ttalk-standard-message/master/jsonschema/apis/types/totvsApiTypesBase.json#/definitions/ErrorModel"
+                }
+              }
+            }
+          }
+        },
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "https://raw.githubusercontent.com/totvs/ttalk-standard-message/MRPBillOfMaterial/V1/1_000/jsonschema/schemas/MRPBillOfMaterial_1_000.json#/definitions/ListOfMRPBillOfMaterial"
+              }
+            }
+          }
+        },
+        "x-totvs": {
+          "productInformation": [
+            {
+              "product": "Protheus",
+              "available": true,
+              "note": "Este verbo está disponível com todos os parâmetros",
+              "minimalVersion": "12.1.27"
+            }
+          ]
+        }
+      }
+    },
+    "/mrpbillofmaterial/{branchId}/{product}": {
+      "get": {
+        "tags": [
+          "mrpbillofmaterial"
+        ],
+        "summary": "Retorna uma estrutura do MRP",
+        "description": "Retorna uma estrutura do MRP",
+        "operationId": "getbillofmaterial",
+        "parameters": [
+          {
+            "$ref": "https://raw.githubusercontent.com/totvs/ttalk-standard-message/master/jsonschema/apis/types/totvsApiTypesBase.json#/parameters/Fields"
+          },
+          {
+            "$ref": "#/components/parameters/branchId"
+          },
+          {
+            "$ref": "#/components/parameters/product"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Operação realizada com sucesso",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "https://raw.githubusercontent.com/totvs/ttalk-standard-message/MRPBillOfMaterial/V1/1_000/jsonschema/schemas/MRPBillOfMaterial_1_000.json#/definitions/MRPBillOfMaterial"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Estrutura do MRP não localizada",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "https://raw.githubusercontent.com/totvs/ttalk-standard-message/master/jsonschema/apis/types/totvsApiTypesBase.json#/definitions/ErrorModel"
+                }
+              }
+            }
+          }
+        },
+        "x-totvs": {
+          "productInformation": [
+            {
+              "product": "Protheus",
+              "available": true,
+              "note": "Este verbo está disponível com todos os parâmetros",
+              "minimalVersion": "12.1.27"
+            }
+          ]
+        }
+      }
+    },
+    "/mrpbillofmaterial/component": {
+      "delete": {
+        "tags": [
+          "mrpbillofmaterial"
+        ],
+        "summary": "Remove um ou mais componentes das estruturas do MRP",
+        "description": "Remove um ou mais componentes das estruturas do MRP",
+        "operationId": "deletecomponentmrpbillofmaterial",
+        "responses": {
+          "204": {
+            "description": "Operação realizada com sucesso"
+          },
+          "207": {
+            "description": "Operação realizada parcialmente com sucesso",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "https://raw.githubusercontent.com/totvs/ttalk-standard-message/MRPBillOfMaterial/V1/1_000/jsonschema/schemas/MRPBillOfMaterial_1_000.json#/definitions/MRPBillOfMaterialMultiple"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Erro no momento da exclusão",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "https://raw.githubusercontent.com/totvs/ttalk-standard-message/master/jsonschema/apis/types/totvsApiTypesBase.json#/definitions/ErrorModel"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Componente não localizado na estrutura do MRP",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "https://raw.githubusercontent.com/totvs/ttalk-standard-message/master/jsonschema/apis/types/totvsApiTypesBase.json#/definitions/ErrorModel"
+                }
+              }
+            }
+          }
+        },
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "https://raw.githubusercontent.com/totvs/ttalk-standard-message/MRPBillOfMaterial/V1/1_000/jsonschema/schemas/MRPBillOfMaterial_1_000.json#/definitions/ListOfMRPBillOfMaterial"
+              }
+            }
+          }
+        },
+        "x-totvs": {
+          "productInformation": [
+            {
+              "product": "Protheus",
+              "available": true,
+              "note": "Este verbo está disponível com todos os parâmetros",
+              "minimalVersion": "12.1.27"
+            }
+          ]
+        }
+      }
+    },
+    "/mrpbillofmaterial/alternative": {
+      "delete": {
+        "tags": [
+          "mrpbillofmaterial"
+        ],
+        "summary": "Remove um ou mais alternativos dos componentes das estruturas do MRP",
+        "description": "Remove um ou mais alternativos dos componentes das estruturas do MRP",
+        "operationId": "deletealternativemrpbillofmaterial",
+        "responses": {
+          "204": {
+            "description": "Operação realizada com sucesso"
+          },
+          "207": {
+            "description": "Operação realizada parcialmente com sucesso",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "https://raw.githubusercontent.com/totvs/ttalk-standard-message/MRPBillOfMaterial/V1/1_000/jsonschema/schemas/MRPBillOfMaterial_1_000.json#/definitions/MRPBillOfMaterialMultiple"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Erro no momento da exclusão",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "https://raw.githubusercontent.com/totvs/ttalk-standard-message/master/jsonschema/apis/types/totvsApiTypesBase.json#/definitions/ErrorModel"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Componente não localizado na estrutura do MRP",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "https://raw.githubusercontent.com/totvs/ttalk-standard-message/master/jsonschema/apis/types/totvsApiTypesBase.json#/definitions/ErrorModel"
+                }
+              }
+            }
+          }
+        },
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "https://raw.githubusercontent.com/totvs/ttalk-standard-message/MRPBillOfMaterial/V1/1_000/jsonschema/schemas/MRPBillOfMaterial_1_000.json#/definitions/ListOfMRPBillOfMaterial"
+              }
+            }
+          }
+        },
+        "x-totvs": {
+          "productInformation": [
+            {
+              "product": "Protheus",
+              "available": true,
+              "note": "Este verbo está disponível com todos os parâmetros",
+              "minimalVersion": "12.1.27"
+            }
+          ]
+        }
+      }
+    }
+  },
+  "components": {
+    "parameters": {
+      "branchId": {
+        "name": "branchId",
+        "in": "path",
+        "description": "Codigo da filial da demanda do MRP",
+        "required": true,
+        "schema": {
+          "type": "string",
+          "format": "char(2)"
+        }
+      },
+      "product": {
+        "name": "product",
+        "in": "path",
+        "description": "Codigo do produto PAI da estrutura do MRP",
+        "required": true,
+        "schema": {
+          "type": "string",
+          "format": "char(90)"
+        }
+      }
+    },
+    "schemas": {}
+  }
 }

--- a/jsonschema/schemas/MRPBillOfMaterial_1_000.json
+++ b/jsonschema/schemas/MRPBillOfMaterial_1_000.json
@@ -415,16 +415,16 @@
 						}
 					]
 				},
-				"codeAlternative": {
-					"description": "Id Alternativo",
+				"sequence": {
+					"description": "Sequência do alternativo",
 					"type": "string",
 					"x-totvs": [
 						{
 							"product": "PROTHEUS",
-							"field": "T4O.T4O_IDALT",
+							"field": "T4O.T4O_SEQ",
 							"required": true,
 							"format": "char",
-							"length": "200",
+							"length": "2",
 							"available": true,
 							"canUpdate": true
 						}

--- a/jsonschema/schemas/MRPBillOfMaterial_1_000.json
+++ b/jsonschema/schemas/MRPBillOfMaterial_1_000.json
@@ -271,9 +271,9 @@
 						}
 					]
 				},
-				"wareHouse": {
+				"warehouse": {
 					"description": "Armazém de consumo",
-					"type": "number",
+					"type": "string",
 					"x-totvs": [
 						{
 							"product": "PROTHEUS",


### PR DESCRIPTION
Atualização da API de estruturas do MRP.
Método DELETE foi dividido em 3 endpoints, sendo um para excluir a estrutura inteira, o /component para excluir determinado componente da estrutura e o /alternative para excluir determinado alternativo de um componente.

Atualizado o endpoint de billofmaterial para mrpbillofmaterial.

Adicionado o campo "sequence" dentro da listOfMRPAlternatives.
Removido o campo "codeAlternative" dentro da listOfMRPAlternatives.