### PR TITLE
Candidates/v2/2_000

### DIFF
--- a/jsonschema/apis/Candidates_v2_000.json
+++ b/jsonschema/apis/Candidates_v2_000.json
@@ -1,0 +1,352 @@
+{
+	"openapi": "3.0.1",
+	"servers": [
+		{
+			"description": "API para a entidade Candidato (Candidates) para produtos TOTVS",
+			"url": "http://{serverUrl}:{serverHttpPort}/api/rh/v1",
+			"variables": {
+				"serverUrl": {
+					"default": "localhost"
+				},
+				"serverHttpPort": {
+					"default": "8051"
+				}
+			}
+		}
+	],
+	"info": {
+		"description": "API para a entidade candidato (Candidates) para produtos TOTVS",
+		"version": "2.000",
+		"title": "Candidato",
+		"contact": {
+			"name": "T-Talk",
+			"url": "API.Totvs.com.br",
+			"email": "comiteintegracao@totvs.com.br"
+		},
+		"x-totvs": {
+			"messageDocumentation": {
+				"name": "Candidates",
+				"description": "Candidato",
+				"segment": "Recursos Humanos"
+			},
+			"productInformation": [
+				{
+					"product": "RM",
+					"contact": "rm_FW@totvs.com.br",
+					"description": "Listagem de Candidatos"
+				},
+				{
+					"product": "Protheus",
+					"contact": "rplyra@totvs.com.br",
+					"description": "Listagem de Candidatos"
+				},
+				{
+					"product": "Datasul",
+					"contact": "triberh.progress.squad.pagadoria@totvs.com.br",
+					"description": "Listagem de Candidatos"
+				}
+			]
+		}
+	},
+	"paths": {
+		"/candidates/{id}": {
+			"get": {
+				"tags": [
+					"Candidates"
+				],
+				"summary": "Retorna dados de tabela do Candidato especificado",
+				"x-totvs": {
+					"productInformation": [
+						{
+							"product": "RM",
+							"available": true,
+							"note": "Este verbo esta disponivel com todos parametros",
+							"minimalVersion": "12.1.23"
+						}
+					]
+				},
+				"description": "Retorna dados de tabela da Candidato especificada",
+				"operationId": "getCandidatesId",
+				"parameters": [
+					{
+						"$ref": "#/components/parameters/CandidatesId"
+					},
+					{
+						"$ref": "https://raw.githubusercontent.com/totvs/ttalk-standard-message/master/jsonschema/apis/types/totvsApiTypesBase.json#/parameters/Authorization"
+					}
+				],
+				"responses": {
+					"200": {
+						"description": "Operação executada com sucesso",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "https://raw.githubusercontent.com/totvs/ttalk-standard-message/Candidates/v2/2_000/jsonschema/schemas/Candidates_2_000.json#/definitions/CandidateInfo"
+								}
+							}
+						}
+					},
+					"400": {
+						"description": "Erro na execução da operação",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "https://raw.githubusercontent.com/totvs/ttalk-standard-message/master/jsonschema/apis/types/totvsApiTypesBase.json#/definitions/ErrorModel"
+								}
+							}
+						}
+					}
+				}
+			},
+			"delete": {
+				"tags": [
+					"Candidates"
+				],
+				"summary": "Exclui Candidato",
+				"x-totvs": {
+					"productInformation": [
+						{
+							"product": "RM",
+							"available": true,
+							"note": "Este verbo esta disponivel com todos parametros",
+							"minimalVersion": "12.1.23"
+						}
+					]
+				},
+				"description": "Exclui Candidato",
+				"operationId": "DeleteCandidatesId",
+				"parameters": [
+					{
+						"$ref": "#/components/parameters/CandidatesId"
+					},
+					{
+						"$ref": "https://raw.githubusercontent.com/totvs/ttalk-standard-message/master/jsonschema/apis/types/totvsApiTypesBase.json#/parameters/Authorization"
+					}
+				],
+				"responses": {
+					"200": {
+						"description": "Operação executada com sucesso"
+					},
+					"400": {
+						"description": "Erro na execução da operação",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "https://raw.githubusercontent.com/totvs/ttalk-standard-message/master/jsonschema/apis/types/totvsApiTypesBase.json#/definitions/ErrorModel"
+								}
+							}
+						}
+					}
+				}
+			},
+			"put": {
+				"tags": [
+					"Candidates"
+				],
+				"summary": "Atualiza um registro existente de tabela de Candidatos",
+				"x-totvs": {
+					"productInformation": [
+						{
+							"product": "RM",
+							"available": true,
+							"note": "Este verbo esta disponivel com todos parametros",
+							"minimalVersion": "12.1.23"
+						}
+					]
+				},
+				"description": "Atualiza um registro existente de tabela de Candidatos. Caso não seja informado alguma propriedade para ser atualizada, está será considerada nula.",
+				"operationId": "putCandidatesId",
+				"parameters": [
+					{
+						"$ref": "#/components/parameters/CandidatesId"
+					},
+					{
+						"$ref": "https://raw.githubusercontent.com/totvs/ttalk-standard-message/master/jsonschema/apis/types/totvsApiTypesBase.json#/parameters/Authorization"
+					}
+				],
+				"requestBody": {
+					"description": "Objeto para atualizar o registro de tabela de Candidatos",
+					"content": {
+						"application/json": {
+							"schema": {
+								"$ref": "https://raw.githubusercontent.com/totvs/ttalk-standard-message/Candidates/v2/2_000/jsonschema/schemas/Candidates_2_000.json#/definitions/CandidateSave"
+							}
+						}
+					}
+				},
+				"responses": {
+					"200": {
+						"description": "Candidatos atualizado com sucesso",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "https://raw.githubusercontent.com/totvs/ttalk-standard-message/Candidates/v2/2_000/jsonschema/schemas/Candidates_2_000.json#/definitions/CandidateInfo"
+								}
+							}
+						}
+					},
+					"400": {
+						"description": "Erro na execução da operação",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "https://raw.githubusercontent.com/totvs/ttalk-standard-message/master/jsonschema/apis/types/totvsApiTypesBase.json#/definitions/ErrorModel"
+								}
+							}
+						}
+					}
+				}
+			}
+		},
+		"/candidates": {
+			"get": {
+				"tags": [
+					"Candidates"
+				],
+				"summary": "Retorna todas as Candidatos",
+				"x-totvs": {
+					"productInformation": [
+						{
+							"product": "RM",
+							"available": true,
+							"note": "Este verbo esta disponível com todos os parâmetros",
+							"minimalVersion": "12.1.23"
+						}
+					]
+				},
+				"description": "Retorna todos as Candidatos",
+				"operationId": "getCandidates",
+				"parameters": [
+					{
+						"$ref": "https://raw.githubusercontent.com/totvs/ttalk-standard-message/master/jsonschema/apis/types/totvsApiTypesBase.json#/parameters/Authorization"
+					},
+					{
+						"$ref": "https://raw.githubusercontent.com/totvs/ttalk-standard-message/master/jsonschema/apis/types/totvsApiTypesBase.json#/parameters/Order"
+					},
+					{
+						"$ref": "https://raw.githubusercontent.com/totvs/ttalk-standard-message/master/jsonschema/apis/types/totvsApiTypesBase.json#/parameters/Page"
+					},
+					{
+						"$ref": "https://raw.githubusercontent.com/totvs/ttalk-standard-message/master/jsonschema/apis/types/totvsApiTypesBase.json#/parameters/PageSize"
+					},
+					{
+						"$ref": "#/components/parameters/CandidatesIds"
+					}
+				],
+				"responses": {
+					"200": {
+						"description": "Operação realizada com sucesso",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "https://raw.githubusercontent.com/totvs/ttalk-standard-message/Candidates/v2/2_000/jsonschema/schemas/Candidates_2_000.json#/definitions/CandidateGroups"
+								}
+							}
+						}
+					},
+					"400": {
+						"description": "Erro no momento da listagem das Candidatos",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "https://raw.githubusercontent.com/totvs/ttalk-standard-message/master/jsonschema/apis/types/totvsApiTypesBase.json#/definitions/ErrorModel"
+								}
+							}
+						}
+					}
+				}
+			},
+			"post": {
+				"tags": [
+					"Candidates"
+				],
+				"summary": "Inclui um novo registro na tabela de Candidatos",
+				"x-totvs": {
+					"productInformation": [
+						{
+							"product": "RM",
+							"available": true,
+							"note": "Este verbo esta disponivel com todos parametros",
+							"minimalVersion": "12.1.23"
+						},
+						{
+							"product": "Protheus",
+							"available": true,
+							"note": "Este verbo esta disponivel com todos parametros",
+							"minimalVersion": "12.1.25"
+						},
+						{
+							"product": "Datasul",
+							"available": true,
+							"note": "Este verbo está disponível com todos parâmetros",
+							"minimalVersion": "12.1.26"
+						}
+					]
+				},
+				"parameters": [
+					{
+						"$ref": "https://raw.githubusercontent.com/totvs/ttalk-standard-message/master/jsonschema/apis/types/totvsApiTypesBase.json#/parameters/Authorization"
+					}
+				],
+				"description": "Inclui um novo registro na tabela de Candidatos",
+				"operationId": "postCandidates",
+				"requestBody": {
+					"description": "Objeto para atualizar o registro de tabela de Candidatos",
+					"content": {
+						"application/json": {
+							"schema": {
+								"$ref": "https://raw.githubusercontent.com/totvs/ttalk-standard-message/Candidates/v2/2_000/jsonschema/schemas/Candidates_2_000.json#/definitions/CandidateSave"
+							}
+						}
+					}
+				},
+				"responses": {
+					"200": {
+						"description": "Operação executada com sucesso",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "https://raw.githubusercontent.com/totvs/ttalk-standard-message/Candidates/v2/2_000/jsonschema/schemas/Candidates_2_000.json#/definitions/CandidateInfo"
+								}
+							}
+						}
+					},
+					"400": {
+						"description": "Erro na execução da operação",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "https://raw.githubusercontent.com/totvs/ttalk-standard-message/master/jsonschema/apis/types/totvsApiTypesBase.json#/definitions/ErrorModel"
+								}
+							}
+						}
+					}
+				}
+			}
+		}
+	},
+	"components": {
+		"parameters": {
+			"CandidatesId": {
+				"name": "id",
+				"in": "path",
+				"required": true,
+				"description": "Identificador Único representando a Candidato",
+				"schema": {
+					"type": "string"
+				}
+			},
+			"CandidatesIds": {
+				"name": "personsIds",
+				"in": "query",
+				"description": "Códigos das Candidatos retornados pelo get separado por vírgula (,) ",
+				"required": false,
+				"example": "param1,param2",
+				"schema": {
+					"type": "string"
+				}
+			}
+		},
+		"schemas": {}
+	}
+}

--- a/jsonschema/schemas/Candidates_2_000.json
+++ b/jsonschema/schemas/Candidates_2_000.json
@@ -1,0 +1,4194 @@
+{
+	"$schema": "https://raw.githubusercontent.com/totvs/ttalk-standard-message/Candidates/v2/2_000/jsonschema/schemas/Candidates_2_000.json#",
+	"info": {
+		"description": "API para a entidade Candidato (Candidates) para produtos TOTVS",
+		"version": "2.000",
+		"title": "Candidates",
+		"contact": {
+			"name": "T-Talk",
+			"url": "API.Totvs.com.br",
+			"email": "comiteintegracao@totvs.com.br"
+		},
+		"x-totvs": {
+			"messageDocumentation": {
+				"name": "Candidates",
+				"description": "Candidatos",
+				"segment": "RH"
+			},
+			"productInformation": [
+				{
+					"product": "RM",
+					"contact": "rm_FW@totvs.com.br",
+					"description": "Listagem de Candidatos"
+				},
+				{
+					"product": "Protheus",
+					"contact": "rplyra@totvs.com.br",
+					"description": "Listagem de Candidatos"
+				},
+				{
+				  "product": "Datasul",
+				  "contact": "triberh.progress.squad.pagadoria@totvs.com.br",
+				  "description": "Listagem de Candidatos"
+				}
+			]
+		}
+	},
+	"definitions": {
+		"CandidateGroups": {
+			"type": "object",
+			"allOf": [
+				{
+					"$ref": "https://raw.githubusercontent.com/totvs/ttalk-standard-message/master/jsonschema/apis/types/totvsApiTypesBase.json#/definitions/Paging"
+				},
+				{
+					"type": "object",
+					"properties": {
+						"items": {
+							"$ref": "#/definitions/CandidateInfo"
+						}
+					}
+				}
+			]
+		},
+		"CandidateInfo": {
+			"type": "object",
+			"allOf": [
+				{
+					"$ref": "#/definitions/CandidateSave"
+				},
+				{
+					"type": "object",
+					"properties": {
+						"Code": {
+							"type": "integer",
+							"format": "int32",
+							"example": "1",
+							"description": "Código do Candidato",
+							"x-totvs": [
+								{
+									"product": "Protheus",
+									"field": "SQGXX0.QG_CURRIC",
+									"required": true,
+									"type": "varchar",
+									"available": true,
+									"canUpdate": false
+								},
+								{
+									"product": "RM",
+									"field": "PPESSOA.CODIGO",
+									"required": true,
+									"type": "varchar",
+									"available": true,
+									"canUpdate": false
+								},
+								{
+									"product": "DATASUL",
+									"field": "CANDIDATO_EXT.CDN_CANDEMPR",
+									"type": "integer",
+									"required": true,
+									"available": true,
+									"canUpdate": false
+								}								
+							]
+						},
+						"RowState": {
+							"type": "integer",
+							"format": "int16",
+							"example": "1",
+							"description": "Estado da row no Dataserver",
+							"x-totvs": [
+								{
+									"product": "Protheus",
+									"field": "",
+									"required": false,
+									"type": "varchar",
+									"available": true,
+									"canUpdate": false,
+									"note":""
+								},
+								{
+									"product": "RM",
+									"required": false,
+									"type": "smallint",
+									"available": true,
+									"canUpdate": true
+								},
+								{
+									"product": "DATASUL",
+									"field": "",
+									"type": "string",
+									"required": false,
+									"available": true,
+									"note": ""
+								}
+							]
+						},
+						"ValidRow": {
+							"type": "integer",
+							"format": "int16",
+							"example": "1",
+							"description": "Se o registro foi validado",
+							"x-totvs": [
+								{
+									"product": "Protheus",
+									"field": "",
+									"required": false,
+									"type": "varchar",
+									"available": true,
+									"canUpdate": false
+								},
+								{
+									"product": "RM",
+									"required": false,
+									"type": "smallint",
+									"available": true,
+									"canUpdate": true
+								},
+								{
+									"product": "DATASUL",
+									"field": "",
+									"type": "string",
+									"required": false,
+									"available": true,
+									"note": ""
+								}
+							]
+						}
+					}
+				}
+			]
+		},
+		"CandidateSave": {
+			"type": "object",
+			"properties": {
+				"id": {
+					"description": "Código do Candidato",
+					"type": "string",
+					"x-totvs": [
+						{
+							"product": "Protheus",
+							"available": true,
+							"field": "SQGXX0.QG_CURRIC",
+							"type": "string",
+							"required": false,
+							"canUpdate": false,
+							"note":""
+						},
+						{
+							"product": "RM",
+							"field": "VCANDIDATOS.CODPESSOA",
+							"required": false,
+							"type": "string",
+							"available": true,
+							"note": "Código do Candidato",
+							"canUpdate": false
+						},
+						{
+							"product": "DATASUL",
+							"field": "CANDIDATO_EXT.CDN_CANDEMPR",
+							"type": "integer",
+							"required": false,
+							"available": false,
+							"canUpdate": false,
+							"note": "Criado internamente pelo Produto Datasul."
+						}
+					]
+				},
+				"companyId": {
+					"type": "string",
+					"example": "1",
+					"description": "Código da Empresa/Coligada",
+					"x-totvs": [
+						{
+							"product": "Protheus",
+							"field": "SM0.M0_CODIGO",
+							"required": true,
+							"type": "varchar",
+							"length": "2",							
+							"available": true,
+							"note": "Grupo de Empresas Protheus",
+							"canUpdate": false
+						},
+						{
+							"product": "RM",
+							"field": "VRECRUTAMENTO.CODCOLIGADA",
+							"required": true,
+							"type": "smallint",
+							"length": "2",							
+							"available": true,
+							"note": "Código da Empresa/Coligada",
+							"canUpdate": false
+						},
+						{
+							"product": "DATASUL",
+							"field": "REQ_PESSOAL.CDN_EMPRESA",
+							"required": true,
+							"type": "string",
+							"length": "3",							
+							"available": true,
+							"note": "Código da Empresa",
+							"canUpdate": false
+						}
+					]
+				},
+				"roleId": {
+					"type": "string",
+					"example": "00001",
+					"description": "Código do Cargo/Função",
+					"x-totvs": [
+						{
+							"product": "Protheus",
+							"field": "",
+							"required": false,
+							"type": "varchar",
+							"length": "10",
+							"note": "Código da Função",
+							"available": true,
+							"canUpdate": false
+						},
+						{
+							"product": "RM",
+							"field": "VRECRUTAMENTO.CODFUNCAO",
+							"required": true,
+							"type": "varchar",
+							"length": "10",
+							"note": "Código da Função",
+							"available": true,
+							"canUpdate": false
+						},
+						{
+							"product": "DATASUL",
+							"field": "REQ_PESSOAL.CDN_CARGO_BASIC + - + REQ_PESSOAL.CDN_NIV_CARGO",
+							"required": true,
+							"type": "string",
+							"length": "5-3",							
+							"available": true,
+							"note": "Chave concatenada do cargo e nível, separados por traço.",
+							"canUpdate": false
+						}
+					]
+				},
+				"departmentId": {
+					"type": "string",
+					"example": "01.01",
+					"description": "Código do Departamento/Seção",
+					"x-totvs": [
+						{
+							"product": "Protheus",
+							"field": "",
+							"required": false,
+							"type": "varchar",
+							"length": "35",
+							"note": "Código da Seção",
+							"available": true,
+							"canUpdate": false
+						},
+						{
+							"product": "RM",
+							"field": "VRECRUTAMENTO.CODSECAO",
+							"required": false,
+							"type": "varchar",
+							"length": "35",
+							"note": "Código da Seção",
+							"available": true,
+							"canUpdate": false
+						},
+						{
+							"product": "DATASUL",
+							"field": "REQ_PESSOAL.COD_UNID_LOTAC",
+							"required": true,
+							"type": "string",
+							"length": "20",							
+							"available": true,
+							"note": "Código da lotação",
+							"canUpdate": false
+						}
+					]
+				},
+				"branchId": {
+					"type": "string",
+					"example": "01 ou D MG 01",
+					"description": "Código da Filial",
+					"x-totvs": [
+						{
+							"product": "Protheus",
+							"field": "SM0.M0_CODFIL",
+							"required": true,
+							"type": "",
+							"length": "",
+							"note": "",
+							"available": true,
+							"canUpdate": false
+						},
+						{
+							"product": "RM",
+							"field": "não possui campo físico na tabela",
+							"required": true,
+							"type": "",
+							"length": "",
+							"note": "",
+							"available": true,
+							"canUpdate": false
+						},
+						{
+							"product": "DATASUL",
+							"field": "REQ_PESSOAL.CDN_ESTAB",
+							"required": true,
+							"type": "string",
+							"length": "5",							
+							"available": true,
+							"note": "Código do estabelecimento",
+							"canUpdate": false
+						}
+					]
+				},
+				"name": {
+					"type": "string",
+					"example": "João Pereira da Silva",
+					"description": "Nome da Pessoa",
+					"x-totvs": [
+						{
+							"product": "Protheus",
+							"field": "SQGXX0.QG_NOME",
+							"required": true,
+							"type": "varchar",
+							"available": true,
+                            "canUpdate": false,                            
+							"note":""
+						},
+						{
+							"product": "RM",
+							"field": "PPESSOA.NOME",
+							"required": false,
+							"type": "varchar",
+							"length": "tamanho máximo de 120",
+							"available": true,
+							"canUpdate": true
+						},
+						{
+							"product": "DATASUL",
+							"field": "CANDIDATO_EXT.NOM_CANDEMPR",
+							"type": "string",
+							"required": true,
+							"available": true,
+							"canUpdate": true
+						}
+					]
+				},
+				"birth": {
+					"type": "date",
+					"format": "date-time",
+					"example": "1975-05-26 00:00:00",
+					"description": "Data de aniversário da Pessoa",
+					"x-totvs": [
+						{
+							"product": "Protheus",
+							"field": "SQGXX0.QG_DTNASC",
+							"required": false,
+							"type": "datetime",
+							"available": true,
+                            "canUpdate": false,                            
+							"note":""
+						},
+						{
+							"product": "RM",
+							"field": "PPESSOA.DTNASCIMENTO",
+							"required": false,
+							"type": "datetime",
+							"available": true,
+							"canUpdate": true
+						},
+						{
+							"product": "DATASUL",
+							"field": "CANDIDATO_EXT.DAT_NASCIMENTO",
+							"type": "date",
+							"required": true,
+							"available": true,
+							"canUpdate": true
+						}
+					]
+				},
+				"homeState": {
+					"type": "string",
+					"example": "MG",
+					"description": "Estado natal da pessoa",
+					"x-totvs": [
+						{
+							"product": "Protheus",
+							"field": "SQGXX0.QG_NATURAL",
+							"required": false,
+							"type": "varchar",
+							"available": true,
+                            "canUpdate": false,                            
+							"note":""
+						},
+						{
+							"product": "RM",
+							"field": "PPESSOA.ESTADONATAL",
+							"type": "varchar",
+							"required": false,
+							"canUpdate": true,
+							"available": true
+
+						},
+						{
+							"product": "DATASUL",
+							"field": "CANDIDATO_EXT.COD_UNID_FEDERAC_NASC",
+							"type": "string",
+							"required": true,
+							"canUpdate": true,
+							"available": true
+						}
+					]
+				},
+				"naturalness": {
+					"type": "string",
+					"example": "Belo Horizonte",
+					"description": "Naturalidade da Pessoa",
+					"x-totvs": [
+						{
+							"product": "Protheus",
+							"field": "SQGXX0.QG_MUNNASC",
+							"required": false,
+							"type": "varchar",
+							"available": true,
+                            "canUpdate": false,                            
+							"note":""
+						},
+						{
+							"product": "RM",
+							"field": "PPESSOA.NATURALIDADE",
+							"required": false,
+							"type": "varchar",
+							"length": "tamanho máximo de 40",
+							"available": true,
+							"canUpdate": true
+						},
+						{
+							"product": "DATASUL",
+							"field": "CANDIDATO_EXT.NOM_NATURALIDADE",
+							"type": "string",
+							"required": true,
+							"canUpdate": true,
+							"available": true
+						}
+					]
+				},
+				"nickName": {
+					"type": "string",
+					"example": "Jão",
+					"description": "Apelido da Pessoa",
+					"x-totvs": [
+						{
+							"product": "Protheus",
+							"field": "",
+							"required": false,
+							"type": "varchar",
+							"available": true,
+                            "canUpdate": false,                            
+							"note":""
+						},
+						{
+							"product": "RM",
+							"field": "PPESSOA.APELIDO",
+							"required": false,
+							"type": "varchar",
+							"length": "tamanho máximo de 40",
+							"available": true,
+							"canUpdate": true
+						},
+						{
+							"product": "DATASUL",
+							"field": "RH_PESSOA_FISIC.NOM_ABREV_PESSOA_FISIC",
+							"type": "string",
+							"required": false,
+							"length": "tamanho máximo de 15",
+							"available": true,
+							"canUpdate": true
+						}
+					]
+				},
+				"sex": {
+					"type": "string",
+					"example": "M",
+					"description": "Sexo da pessoa",
+					"x-totvs": [
+						{
+							"product": "Protheus",
+							"field": "SQGXX0.QG_SEXO",
+							"required": false,
+							"type": "varchar",
+							"available": true,
+                            "canUpdate": false                            
+						},
+						{
+							"product": "RM",
+							"field": "PPESSOA.SEXO",
+							"type": "varchar",
+							"required": false,
+							"available": true,
+							"canUpdate": true
+						},
+						{
+							"product": "DATASUL",
+							"field": "CANDIDATO_EXT.IDI_SEXO",
+							"type": "string",
+							"required": false,
+							"available": true,
+							"canUpdate": true
+						}
+					]
+				},
+				"nationality": {
+					"type": "string",
+					"example": "10",
+					"description": "Nacionalidade da pessoa",
+					"x-totvs": [
+						{
+							"product": "Protheus",
+							"field": "SQGXX0.QG_NACIONA",
+							"required": false,
+							"type": "varchar",
+							"available": true,
+                            "canUpdate": false,                            
+							"note":""
+						},
+						{
+							"product": "RM",
+							"field": "PPESSOA.NACIONALIDADE",
+							"required": false,
+							"type": "varchar",
+							"canUpdate": true,
+							"available": true
+						},
+						{
+							"product": "DATASUL",
+							"field": "CANDIDATO_EXT.IDI_ORIG_PESSOA_FISIC",
+							"type": "string",
+							"required": false,
+							"available": true,
+							"note": "Nacionalidade do Candidato. Considera apenas: Brasileiro, Naturalizado. Demais nacionalidades sao tratadas como Estrangeiras"
+						}
+					]
+				},
+				"educationalLevel": {
+					"type": "string",
+					"example": "9",
+					"description": "Grau de instrução da pessoa",
+					"x-totvs": [
+						{
+							"product": "Protheus",
+							"field": "",
+							"required": false,
+							"type": "varchar",
+							"available": true,
+                            "canUpdate": false,                            
+							"note":""
+						},
+						{
+							"product": "RM",
+							"field": "PPESSOA.GRAUINSTRUCAO",
+							"required": false,
+							"type": "varchar",
+							"canUpdate": true,
+							"available": true							
+						},
+						{
+							"product": "DATASUL",
+							"field": "CANDIDATO_EXT.CDN_GRAU_INSTRUC",
+							"type": "string",
+							"required": true,
+							"available": true,
+							"canUpdate": true,
+							"note": "Grau de Instrução do Candidato conforme tabela do eSocial."
+						}
+					]
+				},
+				"street": {
+					"type": "string",
+					"example": "Rua Mata Atlantica",
+					"description": "Rua do endereço da pessoa",
+					"x-totvs": [
+						{
+							"product": "Protheus",
+							"field": "SQGXX0.QG_ENDEREC",
+							"required": false,
+							"type": "varchar",
+							"available": true,
+							"canUpdate": false,
+							"note":"Separar o endereço do numero que usam o mesmo campo"
+						},
+						{
+							"product": "RM",
+							"field": "PPESSOA.RUA",
+							"required": false,
+							"length": "tamanho máximo de 140",
+							"type": "varchar",
+							"canUpdate": true,
+							"available": true
+						},
+						{
+							"product": "DATASUL",
+							"field": "CANDIDATO_EXT.NOM_ENDER_RH",
+							"type": "string",
+							"required": true,
+							"available": true,
+							"canUpdate": true
+						}
+					]
+				},
+				"number": {
+					"type": "string",
+					"example": "333",
+					"description": "Número da casa da pessoa",
+					"x-totvs": [
+						{
+							"product": "Protheus",
+							"field": "SQGXX0.QG_ENDEREC",
+							"required": false,
+							"type": "varchar",
+							"available": true,
+							"canUpdate": false,
+							"note":"Separar o endereço do numero que usam o mesmo campo"
+						},
+						{
+							"product": "RM",
+							"field": "PPESSOA.NUMERO",
+							"required": false,
+							"length": "tamanho máximo de 8",
+							"type": "varchar",
+							"canUpdate": true,
+							"available": true
+						},
+						{
+							"product": "DATASUL",
+							"field": "CANDIDATO_EXT.COD_ENDERECO",
+							"type": "string",
+							"required": false,
+							"available": true,
+							"canUpdate": true
+						}
+					]
+				},
+				"district": {
+					"type": "string",
+					"example": "Planalto",
+					"description": "Bairro do endereço da pessoa",
+					"x-totvs": [
+						{
+							"product": "Protheus",
+							"field": "SQGXX0.QG_BAIRRO",
+							"required": false,
+							"type": "varchar",
+							"available": true,
+							"canUpdate": false,
+							"note":""
+						},
+						{
+							"product": "RM",
+							"field": "PPESSOA.BAIRRO",
+							"length": "tamanho máximo de 80",
+							"required": false,
+							"type": "varchar",
+							"canUpdate": true,
+							"available": true
+						},
+						{
+							"product": "DATASUL",
+							"field": "CANDIDATO_EXT.NOM_BAIRRO_RH",
+							"type": "string",
+							"required": false,
+							"canUpdate": true,
+							"available": true
+						}
+					]
+				},
+				"state": {
+					"type": "string",
+					"example": "MG",
+					"description": "Estado do endereço da pessoa",
+					"x-totvs": [
+						{
+							"product": "Protheus",
+							"field": "SQGXX0.QG_ESTADO",
+							"required": false,
+							"type": "varchar",
+							"available": true,
+							"canUpdate": false,
+							"note":""
+						},
+						{
+							"product": "RM",
+							"field": "PPESSOA.ESTADO",
+							"required": false,
+							"type": "varchar",
+							"canUpdate": true,
+							"available": true
+						},
+						{
+							"product": "DATASUL",
+							"field": "CANDIDATO_EXT.COD_UNID_FEDERAC_RH",
+							"type": "string",
+							"required": true,
+							"available": true,
+							"note": "Estado que consta no endereço do Candidato no Datasul (RS0027 - Aba Endereço)."
+						}
+					]
+				},
+				"city": {
+					"type": "string",
+					"example": "Belo Horizonte",
+					"description": "Cidade do endereço da pessoa",
+					"x-totvs": [
+						{
+							"product": "Protheus",
+							"field": "SQGXX0.QG_MUNICIP",
+							"required": false,
+							"type": "varchar",
+							"available": true,
+							"canUpdate": false,
+							"note":""
+						},
+						{
+							"product": "RM",
+							"field": "PPESSOA.CIDADE",
+							"required": false,
+							"length": "tamanho máximo de 32",
+							"type": "varchar",
+							"available": true,
+							"canUpdate": true
+						},
+						{
+							"product": "DATASUL",
+							"field": "CANDIDATO_EXT.NOM_CIDAD_RH",
+							"type": "string",
+							"required": true,
+							"available": true,
+							"canUpdate": true
+						}
+					]
+				},
+				"cep": {
+					"type": "string",
+					"example": "30100020",
+					"description": "Cep do endereço da pessoa",
+					"x-totvs": [
+						{
+							"product": "Protheus",
+							"field": "SQGXX0.QG_CEP",
+							"required": false,
+							"type": "varchar",
+							"available": true,
+							"canUpdate": false,
+							"note":""
+						},
+						{
+							"product": "RM",
+							"field": "PPESSOA.CEP",
+							"required": false,
+							"length": "tamanho máximo de 9",
+							"type": "varchar",
+							"available": true,
+							"canUpdate": true
+						},
+						{
+							"product": "DATASUL",
+							"field": "CANDIDATO_EXT.COD_CEP_RH",
+							"type": "string",
+							"required": false,
+							"available": true,
+							"canUpdate": true
+						}
+					]
+				},
+				"country": {
+					"type": "string",
+					"example": "Brasil",
+					"description": "País do endereço da pessoa",
+					"x-totvs": [
+						{
+							"product": "Protheus",
+							"field": "",
+							"required": false,
+							"type": "varchar",
+							"available": true,
+							"canUpdate": false,
+							"note":""
+						},
+						{
+							"product": "RM",
+							"field": "PPESSOA.PAIS",
+							"required": false,
+							"length": "tamanho máximo de 60",
+							"type": "varchar",
+							"available": true,
+							"canUpdate": true
+						},
+						{
+							"product": "DATASUL",
+							"field": "CANDIDATO_EXT.COD_PAIS",
+							"type": "string",
+							"required": true,
+							"available": true,
+							"note": "País que consta no endereço do Candidato no Datasul (RS0027 - Aba Endereço)."
+						}
+					]
+				},
+				"professionalRegistrationNumber": {
+					"type": "string",
+					"example": "Reg-00098",
+					"description": "Registro Profissional da pessoa",
+					"x-totvs": [
+						{
+							"product": "Protheus",
+							"field": "",
+							"required": false,
+							"type": "varchar",
+							"available": true,
+							"canUpdate": false,
+							"note":""
+						},
+						{
+							"product": "RM",
+							"field": "PPESSOA.REGPROFISSIONAL",
+							"required": false,
+							"length": "tamanho máximo de 15",
+							"type": "varchar",
+							"available": true,
+							"canUpdate": true
+						},
+						{
+							"product": "DATASUL",
+							"field": "CANDIDATO_EXT.CDN_ENTID_CLAS_PROFIS + DOCUMEN_CANDEMPR.COD_LIVRE_1",
+							"type": "string",
+							"required": false,
+							"available": false,
+							"note":"Campo do sistema ainda não implementado na API. Concatenação da Entidade de Classe com o Número de Registro Profissional do Candidato, separados por traço. Ex.: CRM/PR 12345"	
+						}
+					]
+				},
+				"cpf": {
+					"type": "string",
+					"example": "51427362653",
+					"description": "CPF da pessoa",
+					"x-totvs": [
+						{
+							"product": "Protheus",
+							"field": "SQGXX0.QG_CIC",
+							"required": true,
+							"type": "varchar",
+							"available": true,
+							"canUpdate": false,
+							"note":""
+						},
+						{
+							"product": "RM",
+							"field": "PPESSOA.CPF",
+							"length": "tamanho máximo de 11",
+							"required": false,
+							"type": "varchar",
+							"available": true,
+							"canUpdate": true
+						},
+						{
+							"product": "DATASUL",
+							"field": "CANDIDATO_EXT.COD_ID_FEDER",
+							"type": "string",
+							"required": true,
+							"available": true			
+						}
+					]
+				},
+				"imageId": {
+					"type": "integer",
+					"example": 844,
+					"description": "Identificador da imagem da pessoa",
+					"x-totvs": [
+						{
+							"product": "Protheus",
+							"field": "SQGXX0.QG_BITMAP",
+							"required": false,
+							"type": "varchar",
+							"available": true,
+							"canUpdate": false,
+							"note":""
+						},
+						{
+							"product": "RM",
+							"field": "PPESSOA.IDIMAGEM",
+							"length": "tamanho máximo de 10",
+							"required": false,
+							"type": "int32",
+							"available": true,
+							"canUpdate": true
+						},
+						{
+							"product": "DATASUL",
+							"field": "CANDIDATO_EXT.COD_IMAGEM",
+							"type": "string",
+							"required": false,
+							"available": false,
+							"canUpdate": false,	
+							"note": "Campo do sistema ainda não implementado na API."
+						}
+					]
+				},
+				"phoneNumber1": {
+					"type": "string",
+					"example": "4613636",
+					"description": "Número de telefone 1 da pessoa",
+					"x-totvs": [
+						{
+							"product": "Protheus",
+							"field": "SQGXX0.QG_FONE",
+							"required": false,
+							"type": "varchar",
+							"available": true,
+							"canUpdate": false,
+							"note":""
+						},
+						{
+							"product": "RM",
+							"field": "PPESSOA.TELEFONE1",
+							"length": "tamanho máximo de 15",
+							"required": false,
+							"type": "varchar",
+							"available": true,
+							"canUpdate": true
+						},
+						{
+							"product": "DATASUL",
+							"field": "CANDIDATO_EXT.NUM_DDD + CANDIDATO_EXT.NUM_TELEFONE",
+							"type": "string",
+							"required": false,
+							"available": true,
+							"note": "Concatenação do DDD e Telefone do candidato."
+						}
+					]
+				},
+				"phoneNumber2": {
+					"type": "string",
+					"example": "4613636",
+					"description": "Número de telefone 2 da pessoa",
+					"x-totvs": [
+						{
+							"product": "Protheus",
+							"field": "SQGXX0.QG_FONECEL",
+							"required": false,
+							"type": "varchar",
+							"available": true,
+							"canUpdate": false,
+							"note":""
+						},
+						{
+							"product": "RM",
+							"field": "PPESSOA.TELEFONE2",
+							"length": "tamanho máximo de 15",
+							"required": false,
+							"type": "varchar",
+							"available": true,
+							"canUpdate": true
+						},
+						{
+							"product": "DATASUL",
+							"field": "CANDIDATO_EXT.NUM_DDD_CONTAT + CANDIDATO_EXT.NUM_TELEF_CONTAT",
+							"type": "string",
+							"required": false,
+							"available": true,
+							"note": "Concatenação do DDD e Telefone de Contato do candidato."
+						}
+					]
+				},
+				"identityNumber": {
+					"type": "string",
+					"example": "M 267392",
+					"description": "Identidade da pessoa",
+					"x-totvs": [
+						{
+							"product": "Protheus",
+							"field": "SQGXX0.QG_RG",
+							"required": false,
+							"type": "varchar",
+							"available": true,
+							"canUpdate": false,
+							"note":""
+						},
+						{
+							"product": "RM",
+							"field": "PPESSOA.CARTIDENTIDADE",
+							"length": "tamanho máximo de 15",
+							"required": false,
+							"type": "varchar",
+							"available": true,
+							"canUpdate": true
+						},
+						{
+							"product": "DATASUL",
+							"field": "DOCUMEN_CANDEMPR.COD_ID_ESTAD_FISIC",
+							"type": "string",
+							"required": false,
+							"available": true
+						}
+					]
+				},
+				"identityNumberEmitterState": {
+					"type": "string",
+					"example": "MG",
+					"description": "Estado emissor da identidade da pessoa",
+					"x-totvs": [
+						{
+							"product": "Protheus",
+							"field": "",
+							"required": false,
+							"type": "varchar",
+							"available": true,
+							"canUpdate": false,
+							"note":""
+						},
+						{
+							"product": "RM",
+							"field": "PPESSOA.UFCARTIDENT",
+							"length": "tamanho máximo de 2",
+							"required": false,
+							"type": "varchar",
+							"available": true,
+							"canUpdate": true
+						},
+						{
+							"product": "DATASUL",
+							"field": "DOCUMEN_CANDEMPR.COD_UNID_FEDERAC_EMIS_ESTAD",
+							"type": "string",
+							"required": false,
+							"available": true
+						}
+					]
+				},
+				"identityNumberEmitterAgency": {
+					"type": "string",
+					"example": "SSP",
+					"description": "Orgão emissor da identidade da pessoa",
+					"x-totvs": [
+						{
+							"product": "Protheus",
+							"field": "",
+							"required": false,
+							"type": "varchar",
+							"available": true,
+							"canUpdate": false,
+							"note":""
+						},
+						{
+							"product": "RM",
+							"field": "PPESSOA.ORGEMISSORIDENT",
+							"length": "tamanho máximo de 15",
+							"required": false,
+							"type": "varchar",
+							"available": true,
+							"canUpdate": true
+						},
+						{
+							"product": "DATASUL",
+							"field": "DOCUMEN_CANDEMPR.COD_ORGAO_EMIS_ID_ESTAD",
+							"type": "string",
+							"required": false,
+							"available": true
+						}
+					]
+				},
+				"identityNumberEmissionDate": {
+					"type": "date",
+					"format": "date-time",
+					"example": "1975-05-26 00:00:00",
+					"description": "Data de emissão da identidade da pessoa",
+					"x-totvs": [
+						{
+							"product": "Protheus",
+							"field": "",
+							"required": false,
+							"type": "datetime",
+							"available": true,
+							"canUpdate": false,
+							"note":""
+						},
+						{
+							"product": "RM",
+							"field": "PPESSOA.DTEMISSAOIDENT",
+							"length": "tamanho máximo de 11",
+							"required": false,
+							"type": "datetime",
+							"available": true,
+							"canUpdate": true
+						},
+						{
+							"product": "DATASUL",
+							"field": "DOCUMEN_CANDEMPR.DAT_EMIS_ID_ESTAD_FISIC",
+							"type": "string",
+							"required": false,
+							"available": true
+						}
+					]
+				},
+				"electoralCard": {
+					"type": "string",
+					"example": "123.334",
+					"description": "Titulo de eleitor da pessoa",
+					"x-totvs": [
+						{
+							"product": "Protheus",
+							"field": "SQGXX0.QG_TITULOE",
+							"required": false,
+							"type": "varchar",
+							"available": true,
+							"canUpdate": false,
+							"note":""
+						},
+						{
+							"product": "RM",
+							"field": "PPESSOA.TITULOELEITOR",
+							"length": "tamanho máximo de 14",
+							"required": false,
+							"type": "varchar",
+							"available": true,
+							"canUpdate": true
+						},
+						{
+							"product": "DATASUL",
+							"field": "DOCUMEN_CANDEMPR.COD_TIT_ELETRAL",
+							"type": "string",
+							"required": false,
+							"available": false,
+							"canUpdate": false,	
+							"note": "Campo do sistema ainda não implementado na API."
+						}
+					]
+				},
+				"electoralWard": {
+					"type": "string",
+					"example": "0012",
+					"description": "Zona eleitoral da pessoa",
+					"x-totvs": [
+						{
+							"product": "Protheus",
+							"field": "SQGXX0.QG_ZONASEC",
+							"required": false,
+							"type": "varchar",
+							"available": true,
+							"canUpdate": false,
+							"note":"O campo possui Zona e Seção, tamanho 4 para Zona e tamanho 4 para Seção"
+						},
+						{
+							"product": "RM",
+							"field": "PPESSOA.ZONATITELEITOR",
+							"length": "tamanho máximo de 6",
+							"required": false,
+							"type": "varchar",
+							"available": true,
+							"canUpdate": true
+						},
+						{
+							"product": "DATASUL",
+							"field": "DOCUMEN_CANDEMPR.NUM_ZONA_TIT_ELETRAL",
+							"type": "integer",
+							"required": false,
+							"available": false,
+							"canUpdate": false,	
+							"note": "Campo do sistema ainda não implementado na API."
+						}
+					]
+				},
+				"electoralSection": {
+					"type": "string",
+					"example": "0006",
+					"description": "Seção eleitoral da pessoa",
+					"x-totvs": [
+						{
+							"product": "Protheus",
+							"field": "SQGXX0.QG_ZONASEC",
+							"required": false,
+							"type": "varchar",
+							"available": true,
+							"canUpdate": false,
+							"note":"O campo possui Zona e Seção, tamanho 4 para Zona e tamanho 4 para Seção"
+						},
+						{
+							"product": "RM",
+							"field": "PPESSOA.SECAOTITELEITOR",
+							"length": "tamanho máximo de 6",
+							"required": false,
+							"type": "varchar",
+							"available": true,
+							"canUpdate": true
+						},
+						{
+							"product": "DATASUL",
+							"field": "DOCUMEN_CANDEMPR.NUM_SECAO_TIT_ELETRAL",
+							"type": "integer",
+							"required": false,
+							"available": false,
+							"canUpdate": false,	
+							"note": "Campo do sistema ainda não implementado na API."
+						}
+					]
+				},
+				"workCard": {
+					"type": "string",
+					"example": "015116",
+					"description": "Carteira de trabalho da pessoa",
+					"x-totvs": [
+						{
+							"product": "Protheus",
+							"field": "SQGXX0.QG_NUMCP",
+							"required": false,
+							"type": "varchar",
+							"available": true,
+							"canUpdate": false,
+							"note":""
+						},
+						{
+							"product": "RM",
+							"field": "PPESSOA.CARTEIRATRAB",
+							"length": "tamanho máximo de 10",
+							"required": false,
+							"type": "varchar",
+							"available": true,
+							"canUpdate": true
+						},
+						{
+							"product": "DATASUL",
+							"field": "DOCUMEN_CANDEMPR.COD_CART_TRAB",
+							"type": "string",
+							"required": false,
+							"available": true
+						}
+					]
+				},
+				"workCardSerialNumber": {
+					"type": "string",
+					"example": "00001",
+					"description": "Número de série da carteira de trabalho da pessoa",
+					"x-totvs": [
+						{
+							"product": "Protheus",
+							"field": "SQGXX0.QG_SERCP",
+							"required": false,
+							"type": "varchar",
+							"available": true,
+							"canUpdate": false,
+							"note":""
+						},
+						{
+							"product": "RM",
+							"field": "PPESSOA.SERIECARTTRAB",
+							"length": "tamanho máximo de 5",
+							"required": false,
+							"type": "varchar",
+							"available": true,
+							"canUpdate": true
+						},
+						{
+							"product": "DATASUL",
+							"field": "DOCUMEN_CANDEMPR.COD_SER_CART_TRAB",
+							"type": "string",
+							"required": false,
+							"available": true
+						}
+					]
+				},
+				"workCardEmitterState": {
+					"type": "string",
+					"example": "MG",
+					"description": "Estado emissor da carteira de trabalho da pessoa",
+					"x-totvs": [
+						{
+							"product": "Protheus",
+							"field": "SQGXX0.QG_UFCP",
+							"required": false,
+							"type": "varchar",
+							"available": true,
+							"canUpdate": false,
+							"note":""
+						},
+						{
+							"product": "RM",
+							"field": "PPESSOA.UFCARTTRAB",
+							"length": "tamanho máximo de 2",
+							"required": false,
+							"type": "varchar",
+							"available": true,
+							"canUpdate": true
+						},
+						{
+							"product": "DATASUL",
+							"field": "DOCUMEN_CANDEMPR.COD_UNID_FEDERAC_CART_TRAB",
+							"type": "string",
+							"required": false,
+							"available": false,
+							"canUpdate": false,	
+							"note": "Campo do sistema ainda não implementado na API."
+						}
+					]
+				},
+				"workCardEmissionDate": {
+					"type": "date",
+					"format": "date-time",
+					"example": "1975-05-26 00:00:00",
+					"description": "Data de emissão da carteira de trabalho da pessoa",
+					"x-totvs": [
+						{
+							"product": "Protheus",
+							"field": "",
+							"required": false,
+							"type": "datetime",
+							"available": true,
+							"canUpdate": false,
+							"note":""
+						},
+						{
+							"product": "RM",
+							"field": "PPESSOA.DTCARTTRAB",
+							"required": false,
+							"type": "datetime",
+							"available": true,
+							"canUpdate": true
+						},
+						{
+							"product": "DATASUL",
+							"field": "DOCUMEN_CANDEMPR.DAT_CART_TRAB",
+							"type": "date",
+							"required": false,
+							"available": false,
+							"canUpdate": false,	
+							"note": "Campo do sistema ainda não implementado na API."
+						}
+					]
+				},
+				"nit": {
+					"type": "boolean",
+					"example": 0,
+					"description": "Indicador de carteira tipo NIT da pessoa",
+					"x-totvs": [
+						{
+							"product": "Protheus",
+							"field": "",
+							"required": false,
+							"type": "varchar",
+							"available": true,
+							"canUpdate": false,
+							"note":""
+						},
+						{
+							"product": "RM",
+							"field": "PPESSOA.NIT",
+							"required": false,
+							"type": "smallint",
+							"available": true,
+							"canUpdate": true
+						},
+						{
+							"product": "DATASUL",
+							"field": "",
+							"type": "string",
+							"required": false,
+							"available": true
+						}
+					]
+				},
+				"driversLicense": {
+					"type": "string",
+					"example": "13.344.543",
+					"description": "Carteira de habilitação da pessoa",
+					"x-totvs": [
+						{
+							"product": "Protheus",
+							"field": "SQGXX0.QG_HABILIT",
+							"required": false,
+							"type": "varchar",
+							"available": true,
+							"canUpdate": false,
+							"note":""
+						},
+						{
+							"product": "RM",
+							"field": "PPESSOA.CARTMOTORISTA",
+							"length": "tamanho máximo de 15",
+							"required": false,
+							"type": "varchar",
+							"available": true,
+							"canUpdate": true
+						},
+						{
+							"product": "DATASUL",
+							"field": "DOCUMEN_CANDEMPR.NUM_CART_HABILIT",
+							"type": "integer",
+							"required": false,
+							"available": false,
+							"canUpdate": false,	
+							"note": "Campo do sistema ainda não implementado na API."
+						}
+					]
+				},
+				"driversLicenseType": {
+					"type": "string",
+					"example": "A",
+					"description": "Tipo de carteira de habilitação da pessoa",
+					"x-totvs": [
+						{
+							"product": "Protheus",
+							"field": "",
+							"required": false,
+							"type": "varchar",
+							"available": true,
+							"canUpdate": false,
+							"note":""
+						},
+						{
+							"product": "RM",
+							"field": "PPESSOA.TIPOCARTHABILIT",
+							"length": "tamanho máximo de 5",
+							"required": false,
+							"type": "varchar",
+							"available": true,
+							"canUpdate": true
+						},
+						{
+							"product": "DATASUL",
+							"field": "DOCUMEN_CANDEMPR.IDI_CATEG_HABILIT_PESSOA",
+							"type": "integer",
+							"required": false,
+							"available": false,
+							"note": "1 = A; 2 = B; 3 = C; 4 = D; 5 = E; 6 = AB; 7 = AC;8 = AD; 9 = AE. Campo do sistema ainda não implementado na API."
+						}
+					]
+				},
+				"driversLicenseExpirationDate": {
+					"type": "date",
+					"format": "date-time",
+					"example": "1975-05-26 00:00:00",
+					"description": "Data de vencimento da carteira de habilitação da pessoa",
+					"x-totvs": [
+						{
+							"product": "Protheus",
+							"field": "",
+							"required": false,
+							"type": "datetime",
+							"available": true,
+							"canUpdate": false,
+							"note":""
+						},
+						{
+							"product": "RM",
+							"field": "PPESSOA.DTVENCHABILIT",
+							"required": false,
+							"type": "datetime",
+							"available": true,
+							"canUpdate": true
+						},
+						{
+							"product": "DATASUL",
+							"field": "DOCUMEN_CANDEMPR.DAT_VALID_CART_HABILIT",
+							"type": "date",
+							"required": false,
+							"available": false,
+							"canUpdate": false,	
+							"note": "Campo do sistema ainda não implementado na API."
+						}
+					]
+				},
+				"militaryDischargeCertificate": {
+					"type": "string",
+					"example": "12856945678",
+					"description": "Certificado de reservista militar da pessoa",
+					"x-totvs": [
+						{
+							"product": "Protheus",
+							"field": "SQGXX0.QG_RESERV",
+							"required": false,
+							"type": "varchar",
+							"available": true,
+							"canUpdate": false,
+							"note":""
+						},
+						{
+							"product": "RM",
+							"field": "PPESSOA.CERTIFRESERV",
+							"length": "tamanho máximo de 11",
+							"required": false,
+							"type": "varchar",
+							"available": true
+						},
+						{
+							"product": "DATASUL",
+							"field": "DOCUMEN_CANDEMPR.COD_DOCTO_MILIT",
+							"type": "string",
+							"required": false,
+							"available": false,
+							"canUpdate": false,	
+							"note": "Campo do sistema ainda não implementado na API."
+						}
+					]
+				},
+				"militaryGrade": {
+					"type": "string",
+					"example": "CDI",
+					"description": "Categoria militar da pessoa",
+					"x-totvs": [
+						{
+							"product": "Protheus",
+							"field": "",
+							"required": false,
+							"type": "varchar",
+							"available": true,
+							"canUpdate": false,
+							"note":""
+						},
+						{
+							"product": "RM",
+							"field": "PPESSOA.CATEGMILITAR",
+							"length": "tamanho máximo de 10",
+							"required": false,
+							"type": "varchar",
+							"available": true,
+							"canUpdate": false
+						},
+						{
+							"product": "DATASUL",
+							"field": "DOCUMEN_CANDEMPR.IDI_TIP_DOCTO_MILIT",
+							"type": "integer",
+							"required": false,
+							"available": false,
+							"note": "Campo do sistema ainda não implementado na API. 1 - Carteira Reservista; 2 - Certificado Dispensa; 3 - Não Possui"
+						}
+					]
+				},
+				"brazilConsort": {
+					"type": "boolean",
+					"example": 0,
+					"description": "Indicador para caso a pessoa tenha um conjuge no Brasil",
+					"x-totvs": [
+						{
+							"product": "Protheus",
+							"field": "",
+							"required": false,
+							"type": "varchar",
+							"available": true,
+							"canUpdate": false,
+							"note":""
+						},
+						{
+							"product": "RM",
+							"field": "PPESSOA.CONJUGEBRASIL",
+							"required": false,
+							"type": "smallint",
+							"available": true,
+							"canUpdate": false
+						},
+						{
+							"product": "DATASUL",
+							"field": "COMPL_PESSOA_FISIC.LOG_ESTRANG_CASAD_BRAS",
+							"type": "boolean",
+							"required": false,
+							"available": false, 
+							"note": "Campo do sistema ainda não implementado na API. Aceita True ou False"
+						}
+					]
+				},
+				"naturalized": {
+					"type": "boolean",
+					"example": 0,
+					"description": "Indicador caso a pessoa seja naturalizada",
+					"x-totvs": [
+						{
+							"product": "Protheus",
+							"field": "",
+							"required": false,
+							"type": "varchar",
+							"available": true,
+							"canUpdate": false,
+							"note":""
+						},
+						{
+							"product": "RM",
+							"field": "PPESSOA.NATURALIZADO",
+							"required": false,
+							"type": "smallint",
+							"available": true,
+							"canUpdate": false
+						},
+						{
+							"product": "DATASUL",
+							"field": "CANDIDATO_EXT.IDI_ORIG_PESSOA_FISIC",
+							"type": "integer",
+							"required": false,
+							"available": false,
+							"note": "Campo ainda não implementado na API. 1 = Brasileiro; 2 = Naturalizado; 3 = Estrangeiro"
+						}
+					]
+				},
+				"brazilianChildren": {
+					"type": "boolean",
+					"example": 0,
+					"description": "Indicador caso a pessoa tenha filhos brasileiros",
+					"x-totvs": [
+						{
+							"product": "Protheus",
+							"field": "",
+							"required": false,
+							"type": "varchar",
+							"available": true,
+							"canUpdate": false,
+							"note":""
+						},
+						{
+							"product": "RM",
+							"field": "PPESSOA.FILHOSBRASIL",
+							"required": false,
+							"type": "smallint",
+							"available": true,
+							"canUpdate": false
+						},
+						{
+							"product": "DATASUL",
+							"field": "COMPL_PESSOA_FISIC.LOG_POSSUI_FILHO_BRAS",
+							"type": "boolean",
+							"required": false,
+							"available": false, 
+							"note": "Campo do sistema ainda não implementado na API. Aceita True ou False"
+						}
+					]
+				},
+				"brazilianChildrenNumber": {
+					"type": "integer",
+					"format": "int32",
+					"example": "2",
+					"description": "Números de filhos brasileiros da pessoa",
+					"x-totvs": [
+						{
+							"product": "Protheus",
+							"field": "",
+							"required": false,
+							"type": "varchar",
+							"available": true,
+							"canUpdate": false,
+							"note":""
+						},
+						{
+							"product": "RM",
+							"field": "PPESSOA.FILHOSBRASIL",
+							"required": false,
+							"type": "smallint",
+							"available": true,
+							"canUpdate": false
+						},
+						{
+							"product": "DATASUL",
+							"field": "",
+							"type": "boolean",
+							"required": false,
+							"available": false,
+							"canUpdate": false,	
+							"note": "Campo do sistema ainda não implementado na API."
+						}
+					]
+				},
+				"email": {
+					"type": "string",
+					"example": "teste@totvs.com.br",
+					"description": "Email da pessoa",
+					"x-totvs": [
+						{
+							"product": "Protheus",
+							"field": "SQGXX0.QG_EMAIL",
+							"required": false,
+							"type": "varchar",
+							"available": true,
+							"canUpdate": false,
+							"note":""
+						},
+						{
+							"product": "RM",
+							"field": "PPESSOA.EMAIL",
+							"length": "tamanho máximo de 60",
+							"required": false,
+							"type": "varchar",
+							"available": true,
+							"canUpdate": false
+						},
+						{
+							"product": "DATASUL",
+							"field": "CANDIDATO_EXT.NOM_E_MAIL",
+							"type": "string",
+							"required": false,
+							"available": true
+						}
+					]
+				},
+				"previousTrainingInvestment": {
+					"type": "double",
+					"example": "2300.00",
+					"description": "Valor de investimentos em treinamentos anteriores da pessoa",
+					"x-totvs": [
+						{
+							"product": "Protheus",
+							"field": "",
+							"required": false,
+							"type": "integer",
+							"available": true,
+							"canUpdate": false,
+							"note":""
+						},
+						{
+							"product": "RM",
+							"field": "PPESSOA.INVESTTREINANT",
+							"length": "tamanho máximo de 15 com 2 casas decimais",
+							"required": false,
+							"type": "decimal",
+							"available": true,
+							"canUpdate": false
+						},
+						{
+							"product": "DATASUL",
+							"field": "",
+							"type": "string",
+							"required": false,
+							"available": false
+						}
+					]
+				},
+				"shadeRace": {
+					"type": "integer",
+					"example": "0",
+					"description": "Raça ou Cor da pessoa",
+					"x-totvs": [
+						{
+							"product": "Protheus",
+							"field": "",
+							"required": false,
+							"type": "varchar",
+							"available": true,
+							"canUpdate": false,
+							"note":""
+						},
+						{
+							"product": "RM",
+							"field": "PPESSOA.CORRACA",
+							"required": false,
+							"type": "smallint",
+							"available": true,
+							"canUpdate": false
+						},
+						{
+							"product": "DATASUL",
+							"field": "CANDIDATO_EXT.IDI_COR_CUTIS",
+							"type": "integer",
+							"required": false,
+							"available": false, 
+							"note": "Campo do sistema ainda não implementado na API. 1 = Branca; 2 = Preta; 3 = Parda; 4 = Amarela; 5 = Não Informada; 6 = Indígena"
+						}
+					]
+				},
+				"disabled": {
+					"type": "boolean",
+					"example": 0,
+					"description": "Indicador para pessoa deficiente física",
+					"x-totvs": [
+						{
+							"product": "Protheus",
+							"field": "SQGXX0.QG_DFISICO",
+							"required": false,
+							"type": "varchar",
+							"available": true,
+							"canUpdate": false,
+							"note":""
+						},
+						{
+							"product": "RM",
+							"field": "PPESSOA.DEFICIENTEFISICO",
+							"required": false,
+							"type": "smallint",
+							"available": true,
+							"canUpdate": false
+						},
+						{
+							"product": "DATASUL",
+							"field": "RH_PESSOA_FISIC.LOG_LIVRE_1",
+							"type": "boolean",
+							"required": false,
+							"available": true, 
+							"note": "Aceita True ou False"
+						}
+					]
+				},
+				"userCode": {
+					"type": "string",
+					"example": "simone",
+					"description": "Código de usuário da pessoa",
+					"x-totvs": [
+						{
+							"product": "Protheus",
+							"field": "",
+							"required": false,
+							"type": "varchar",
+							"available": true,
+							"canUpdate": false,
+							"note":""
+						},
+						{
+							"product": "RM",
+							"field": "PPESSOA.CODUSUARIO",
+							"length": "tamanho máximo de 20",
+							"required": false,
+							"type": "varchar",
+							"available": true,
+							"canUpdate": false
+						},
+						{
+							"product": "DATASUL",
+							"field": "",
+							"type": "string",
+							"required": false,
+							"available": true
+						}
+					]
+				},
+				"phoneNumber3": {
+					"type": "string",
+					"example": "21229000",
+					"description": "Telefone 3 da pessoa",
+					"x-totvs": [
+						{
+							"product": "Protheus",
+							"field": "SQGXX0.QG_FONECOM",
+							"required": false,
+							"type": "varchar",
+							"available": true,
+							"canUpdate": false,
+							"note":"telefone comercial"
+						},
+						{
+							"product": "RM",
+							"field": "PPESSOA.TELEFONE3",
+							"length": "tamanho máximo de 15",
+							"required": false,
+							"type": "varchar",
+							"available": true,
+							"canUpdate": false
+						},
+						{
+							"product": "DATASUL",
+							"field": "CANDIDATO_EXT.NUM_DDD_COMERC + CANDIDATO_EXT.NUM_TELEF_COMERC",
+							"type": "string",
+							"required": false,
+							"available": false,
+							"note": "Campo do sistema ainda não implementado na API. Concatenação do DDD e Telefone Comercial do candidato. "
+						}
+					]
+				},
+				"company": {
+					"type": "string",
+					"example": "RM SISTEMAS S.A",
+					"description": "Empresa da pessoa",
+					"x-totvs": [
+						{
+							"product": "Protheus",
+							"field": "",
+							"required": true,
+							"type": "varchar",
+							"available": true,
+							"canUpdate": false,
+							"note":""
+						},
+						{
+							"product": "RM",
+							"field": "PPESSOA.EMPRESA",
+							"length": "tamanho máximo de 60",
+							"required": false,
+							"type": "varchar",
+							"available": true,
+							"canUpdate": false
+						},
+						{
+							"product": "DATASUL",
+							"field": "",
+							"type": "string",
+							"required": false,
+							"available": true
+							
+						}
+					]
+				},
+				"occupationCode": {
+					"type": "string",
+					"example": "10",
+					"description": "Código de ocupação da pessoa",
+					"x-totvs": [
+						{
+							"product": "Protheus",
+							"field": "",
+							"required": false,
+							"type": "varchar",
+							"available": true,
+							"canUpdate": false,
+							"note":""
+						},
+						{
+							"product": "RM",
+							"field": "PPESSOA.CODOCUPACAO",
+							"length": "tamanho máximo de 3",
+							"required": false,
+							"type": "varchar",
+							"available": true,
+							"canUpdate": false
+						},
+						{
+							"product": "DATASUL",
+							"field": "",
+							"type": "boolean",
+							"required": false,
+							"available": true
+						}
+					]
+				},
+				"rehabilitated": {
+					"type": "boolean",
+					"example": 0,
+					"description": "Indicador de pessoa reabilitada",
+					"x-totvs": [
+						{
+							"product": "Protheus",
+							"field": "",
+							"required": false,
+							"type": "varchar",
+							"available": true,
+							"canUpdate": false,
+							"note":""
+						},
+						{
+							"product": "RM",
+							"field": "PPESSOA.BRPDH",
+							"required": false,
+							"type": "smallint",
+							"available": true,
+							"canUpdate": false
+						},
+						{
+							"product": "DATASUL",
+							"field": "DEFCNCIA_PACIEN.LOG_REAVAL",
+							"type": "boolean",
+							"required": false,
+							"available": false,
+							"canUpdate": false,	
+							"note": "Campo do sistema ainda não implementado na API."
+						}
+					]
+				},
+				"smoker": {
+					"type": "boolean",
+					"example": 0,
+					"description": "Indicador de pessoa fumante",
+					"x-totvs": [
+						{
+							"product": "Protheus",
+							"field": "",
+							"required": false,
+							"type": "varchar",
+							"available": true,
+							"canUpdate": false,
+							"note":""
+						},
+						{
+							"product": "RM",
+							"field": "PPESSOA.FUMANTE",
+							"required": false,
+							"type": "smallint",
+							"available": true,
+							"canUpdate": false
+						},
+						{
+							"product": "DATASUL",
+							"field": "CANDIDATO_EXT.IDI_CANDEMPR_FUMANTE",
+							"type": "integer",
+							"required": false,
+							"available": false,
+							"canUpdate": false,	
+							"note": "Campo do sistema ainda não implementado na API."
+						}
+					]
+				},
+				"adjustsImageSize": {
+					"type": "boolean",
+					"example": 0,
+					"description": "Indicador de ajuste do tamanho da foto da pessoa",
+					"x-totvs": [
+						{
+							"product": "Protheus",
+							"field": "",
+							"required": false,
+							"type": "varchar",
+							"available": true,
+							"canUpdate": false,
+							"note":""
+						},
+						{
+							"product": "RM",
+							"field": "PPESSOA.AJUSTATAMANHOFOTO",
+							"required": false,
+							"type": "smallint",
+							"available": true,
+							"canUpdate": false
+						},
+						{
+							"product": "DATASUL",
+							"field": "",
+							"type": "string",
+							"required": false,
+							"available": true
+						}
+					]
+				},
+				"deafPerson": {
+					"type": "boolean",
+					"example": 0,
+					"description": "Indicador de pessoa deficiente auditiva",
+					"x-totvs": [
+						{
+							"product": "Protheus",
+							"field": "",
+							"required": false,
+							"type": "varchar",
+							"available": true,
+							"canUpdate": false,
+							"note":""
+						},
+						{
+							"product": "RM",
+							"field": "PPESSOA.DEFICIENTEAUDITIVO",
+							"required": false,
+							"type": "smallint",
+							"available": true,
+							"canUpdate": false
+						},
+						{
+							"product": "DATASUL",
+							"field": "DEFCNCIA_PACIEN.COD_DEFCNCIA_FISIC",
+							"type": "string",
+							"required": false,
+							"available": false,
+							"note": "Campo do sistema ainda não implementado na API. Cujo tipo de definiciência seja Auditiva (MT0055)."
+						}
+					]
+				},
+				"mutePerson": {
+					"type": "boolean",
+					"example": 0,
+					"description": "Indicador de pessoa deficiente de fala",
+					"x-totvs": [
+						{
+							"product": "Protheus",
+							"field": "",
+							"required": false,
+							"type": "varchar",
+							"available": true,
+							"canUpdate": false,
+							"note":""
+						},
+						{
+							"product": "RM",
+							"field": "PPESSOA.DEFICIENTEFALA",
+							"required": false,
+							"type": "smallint",
+							"available": true,
+							"canUpdate": false
+						},
+						{
+							"product": "DATASUL",
+							"field": "",
+							"type": "string",
+							"required": false,
+							"available": true
+						}
+					]
+				},
+				"blindPerson": {
+					"type": "boolean",
+					"example": 0,
+					"description": "Indicador de pessoa deficiente visual",
+					"x-totvs": [
+						{
+							"product": "Protheus",
+							"field": "",
+							"required": false,
+							"type": "varchar",
+							"available": true,
+							"canUpdate": false,
+							"note":""
+						},
+						{
+							"product": "RM",
+							"field": "PPESSOA.DEFICIENTEVISUAL",
+							"required": false,
+							"type": "smallint",
+							"available": true,
+							"canUpdate": false
+						},
+						{
+							"product": "DATASUL",
+							"field": "DEFCNCIA_PACIEN.COD_DEFCNCIA_FISIC",
+							"type": "string",
+							"required": false,
+							"available": false,
+							"canUpdate": false,	
+							"note": "Campo do sistema ainda não implementado na API."
+						}
+					]
+				},
+				"mentallyImpairedPerson": {
+					"type": "boolean",
+					"example": 0,
+					"description": "Indicador de pessoa com deficiencia mental",
+					"x-totvs": [
+						{
+							"product": "Protheus",
+							"field": "",
+							"required": false,
+							"type": "varchar",
+							"available": true,
+							"canUpdate": false,
+							"note":""
+						},
+						{
+							"product": "RM",
+							"field": "PPESSOA.DEFICIENTEMENTAL",
+							"required": false,
+							"type": "smallint",
+							"available": true,
+							"canUpdate": false
+						},
+						{
+							"product": "DATASUL",
+							"field": "DEFCNCIA_PACIEN.COD_DEFCNCIA_FISIC",
+							"type": "string",
+							"required": false,
+							"available": false,
+							"canUpdate": false,	
+							"note": "Campo do sistema ainda não implementado na API."
+						}
+					]
+				},
+				"curriculumApprovalDate": {
+					"type": "date",
+					"format": "date-time",
+					"example": "1975-05-26 00:00:00",
+					"description": "Data de aprovação do currículo da pessoa",
+					"x-totvs": [
+						{
+							"product": "Protheus",
+							"field": "",
+							"required": false,
+							"type": "varchar",
+							"available": true,
+							"canUpdate": false,
+							"note":""
+						},
+						{
+							"product": "RM",
+							"field": "PPESSOA.DATAAPROVACAOCURR",
+							"required": false,
+							"type": "datetime",
+							"available": true,
+							"canUpdate": false
+						},
+						{
+							"product": "DATASUL",
+							"field": "CANDIDATO_EXT.DAT_ANALIS_CURRIC_CANDEMPR",
+							"type": "date",
+							"required": false,
+							"available": false,							
+							"note": "Campo do sistema ainda não implementado na API."
+						}
+					]
+				},
+				"student": {
+					"type": "boolean",
+					"example": 1,
+					"description": "Indicador de pessoa estudante",
+					"x-totvs": [
+						{
+							"product": "Protheus",
+							"field": "",
+							"required": false,
+							"type": "varchar",
+							"available": true,
+							"canUpdate": false,
+							"note":""
+						},
+						{
+							"product": "RM",
+							"field": "PPESSOA.ALUNO",
+							"required": false,
+							"type": "smallint",
+							"available": true,
+							"canUpdate": false
+						},
+						{
+							"product": "DATASUL",
+							"field": "",
+							"type": "string",
+							"required": false,
+							"available": true
+						}
+					]
+				},
+				"teacher": {
+					"type": "boolean",
+					"example": 1,
+					"description": "Indicador de pessoa professor",
+					"x-totvs": [
+						{
+							"product": "Protheus",
+							"field": "",
+							"required": false,
+							"type": "varchar",
+							"available": true,
+							"canUpdate": false,
+							"note":""
+						},
+						{
+							"product": "RM",
+							"field": "PPESSOA.PROFESSOR",
+							"required": false,
+							"type": "smallint",
+							"available": true,
+							"canUpdate": false
+						},
+						{
+							"product": "DATASUL",
+							"field": "",
+							"type": "string",
+							"required": false,
+							"available": true
+						}
+					]
+				},
+				"candidate": {
+					"type": "boolean",
+					"example": 1,
+					"description": "Indicador de pessoa candidato",
+					"x-totvs": [
+						{
+							"product": "Protheus",
+							"field": "",
+							"required": false,
+							"type": "varchar",
+							"available": true,
+							"canUpdate": false,
+							"note":""
+						},
+						{
+							"product": "RM",
+							"field": "PPESSOA.CANDIDATO",
+							"required": false,
+							"type": "smallint",
+							"available": true,
+							"canUpdate": false
+						}
+					]
+				},
+				"bibliosUser": {
+					"type": "boolean",
+					"example": 1,
+					"description": "Indicador de pessoa usuária da ferramenta Biblios",
+					"x-totvs": [
+						{
+							"product": "Protheus",
+							"field": "",
+							"required": false,
+							"type": "varchar",
+							"available": true,
+							"canUpdate": false,
+							"note":""
+						},
+						{
+							"product": "RM",
+							"field": "PPESSOA.USUARIOBIBLIOS",
+							"required": false,
+							"type": "smallint",
+							"available": true,
+							"canUpdate": false
+						},
+						{
+							"product": "DATASUL",
+							"field": "",
+							"type": "string",
+							"required": false,
+							"available": true
+						}
+					]
+				},
+				"employee": {
+					"type": "boolean",
+					"example": 1,
+					"description": "Indicador de pessoa funcionária",
+					"x-totvs": [
+						{
+							"product": "Protheus",
+							"field": "TMP.TMP_MAT",
+							"required": false,
+							"type": "boolean",
+							"available": true,
+							"canUpdate": false,
+							"note":"Quando a matricula estiver preenchida retornar .T., caso contrario o retorno é Falso .F."
+						},
+						{
+							"product": "RM",
+							"field": "PPESSOA.FUNCIONARIO",
+							"required": false,
+							"type": "smallint",
+							"available": true,
+							"canUpdate": false
+						},
+						{
+							"product": "DATASUL",
+							"field": "",
+							"type": "string",
+							"required": false,
+							"available": true
+						}
+					]
+				},
+				"formerEmployee": {
+					"type": "boolean",
+					"example": 0,
+					"description": "Indicador de pessoa ex-funcionária",
+					"x-totvs": [
+						{
+							"product": "Protheus",
+							"field": "",
+							"required": false,
+							"type": "varchar",
+							"available": true,
+							"canUpdate": false,
+							"note":""
+						},
+						{
+							"product": "RM",
+							"field": "PPESSOA.EXFUNCIONARIO",
+							"required": false,
+							"type": "smallint",
+							"available": true,
+							"canUpdate": false
+						},
+						{
+							"product": "DATASUL",
+							"field": "",
+							"type": "string",
+							"required": false,
+							"available": true
+						}
+					]
+				},
+				"intellectualImpairedPerson": {
+					"type": "boolean",
+					"example": 0,
+					"description": "Indicador de pessoa com deficiencia intelectual",
+					"x-totvs": [
+						{
+							"product": "Protheus",
+							"field": "",
+							"required": false,
+							"type": "varchar",
+							"available": true,
+							"canUpdate": false,
+							"note":""
+						},
+						{
+							"product": "RM",
+							"field": "PPESSOA.DEFICIENTEINTELECTUAL",
+							"required": false,
+							"type": "smallint",
+							"available": true,
+							"canUpdate": false
+						},
+						{
+							"product": "DATASUL",
+							"field": "DEFCNCIA_PACIEN.COD_DEFCNCIA_FISIC",
+							"type": "string",
+							"required": false,
+							"available": false,							
+							"note": "Campo do sistema ainda não implementado na API."
+						}
+					]
+				},
+				"deceased": {
+					"type": "boolean",
+					"example": 0,
+					"description": "Indicador de pessoa falecida",
+					"x-totvs": [
+						{
+							"product": "Protheus",
+							"field": "",
+							"required": false,
+							"type": "varchar",
+							"available": true,
+							"canUpdate": false,
+							"note":""
+						},
+						{
+							"product": "RM",
+							"field": "PPESSOA.FALECIDO",
+							"required": false,
+							"type": "smallint",
+							"available": true,
+							"canUpdate": false
+						},
+						{
+							"product": "DATASUL",
+							"field": "COMPL_PESSOA_FISIC.DAT_LIVRE_1",
+							"type": "date",
+							"required": false,
+							"available": true,
+							"note": "Se tiver a data preechida, entede-se que é falecido."
+						}
+					]
+				},
+				"age": {
+					"type": "integer",
+					"example": 53,
+					"description": "idade da pessoa",
+					"x-totvs": [
+						{
+							"product": "Protheus",
+							"field": "",
+							"required": false,
+							"type": "varchar",
+							"available": true,
+							"canUpdate": false,
+							"note":""
+						},
+						{
+							"product": "RM",
+							"field": "Campo calculado",
+							"required": false,
+							"type": "int32",
+							"available": true,
+							"canUpdate": false
+						},
+						{
+							"product": "DATASUL",
+							"field": "",
+							"type": "string",
+							"required": false,
+							"available": true
+						}
+					]
+				},
+				"registryDate": {
+					"type": "date",
+					"format": "date-time",
+					"example": "1975-05-26 00:00:00",
+					"description": "Data de cadastramento",
+					"x-totvs": [
+						{
+							"product": "Protheus",
+							"field": "SQGXX0.QG_DTCAD",
+							"required": false,
+							"type": "datetime",
+							"available": true,
+							"canUpdate": false,
+							"note":""
+						},
+						{
+							"product": "RM",
+							"field": "VCANDIDATOS.DATACADASTRAMENTO",
+							"required": false,
+							"type": "datetime",
+							"available": true,
+							"canUpdate": true
+						},
+						{
+							"product": "DATASUL",
+							"field": "CANDIDATO_EXT.DAT_CADASTNTO_CANDEMPR",
+							"type": "date",
+							"required": false,
+							"available": true
+						}
+					]
+				},
+				"wageExpectation": {
+					"type": "number",
+					"format": "double",
+					"example": "1111.32",
+					"description": "Pretenção salarial",
+					"x-totvs": [
+						{
+							"product": "Protheus",
+							"field": "SQGXX0.QG_PRETSAL",
+							"required": false,
+							"type": "integer",
+							"available": true,
+							"canUpdate": false,
+							"note":""
+						},
+						{
+							"product": "RM",
+							"field": "VCANDIDATOS.PRETENSAOSALARIAL",
+							"required": false,
+							"type": "rmdvalor2",
+							"available": true,
+							"canUpdate": true
+						},
+						{
+							"product": "DATASUL",
+							"field": "CANDIDATO_EXT.VAL_PRETNCAO_SAL_CANDEMPR",
+							"type": "double",
+							"required": false,
+							"available": false,							
+							"note": "Campo do sistema ainda não implementado na API."
+						}
+					]
+				},
+				"areaOfInterestCode1": {
+					"type": "integer",
+					"format": "int32",
+					"example": "15",
+					"description": "Código da área de interesse 1",
+					"x-totvs": [
+						{
+							"product": "Protheus",
+							"field": "SQGXX0.QG_AREA",
+							"required": false,
+							"type": "varchar",
+							"available": true,
+							"canUpdate": false,
+							"note":""
+						},
+						{
+							"product": "RM",
+							"field": "VCANDIDATOS.CODAREA1",
+							"required": false,
+							"type": "smallint",
+							"available": true,
+							"canUpdate": true
+						},
+						{
+							"product": "DATASUL",
+							"field": "",
+							"type": "string",
+							"required": false,
+							"available": true						
+						}
+					]
+				},
+				"areaOfInterestCode2": {
+					"type": "integer",
+					"format": "int32",
+					"example": "15",
+					"description": "Código da área de interesse 2",
+					"x-totvs": [
+						{
+							"product": "Protheus",
+							"field": "",
+							"required": false,
+							"type": "varchar",
+							"available": true,
+							"canUpdate": false,
+							"note":""
+						},
+						{
+							"product": "RM",
+							"field": "VCANDIDATOS.CODAREA2",
+							"required": false,
+							"type": "smallint",
+							"available": true,
+							"canUpdate": true
+						},
+						{
+							"product": "DATASUL",
+							"field": "",
+							"type": "string",
+							"required": false,
+							"available": true
+						}
+					]
+				},
+				"wageExpectationTradable": {
+					"type": "integer",
+					"format": "int16",
+					"example": "1",
+					"description": "Pretenção salaria negociável",
+					"x-totvs": [
+						{
+							"product": "Protheus",
+							"field": "",
+							"required": false,
+							"type": "integer",
+							"available": true,
+							"canUpdate": false,
+							"note":""
+						},
+						{
+							"product": "RM",
+							"field": "VCANDIDATOS.PRETENSAOSALNEGOCIAVEL",
+							"required": false,
+							"type": "smallint",
+							"available": true,
+							"canUpdate": true
+						},
+						{
+							"product": "DATASUL",
+							"field": "CANDIDATO_EXT.LOG_SALARIO_COMBINAR",
+							"type": "boolean",
+							"required": false,
+							"available": false,							
+							"note": "Campo do sistema ainda não implementado na API."
+						}
+					]
+				},
+				"workExperienceTime": {
+					"type": "integer",
+					"format": "int32",
+					"example": "15",
+					"description": "Tempo de experiência profissional",
+					"x-totvs": [
+						{
+							"product": "Protheus",
+							"field": "SQGXX0.QG_TPEXPER",
+							"required": false,
+							"type": "integer",
+							"available": true,
+							"canUpdate": false,
+							"note":""
+						},
+						{
+							"product": "RM",
+							"field": "VCANDIDATOS.TEMPOEXPPROF",
+							"required": false,
+							"type": "int",
+							"available": true,
+							"canUpdate": true
+						},
+						{
+							"product": "DATASUL",
+							"field": "EMPRES_ANT_CANDIDATO_EXT.NUM_MESES_TRABDO_CANDEMPR",
+							"type": "integer",
+							"required": false,
+							"available": false,							
+							"note": "Campo do sistema ainda não implementado na API."
+						}
+					]
+				},
+				"workExperienceTimeArea1": {
+					"type": "integer",
+					"format": "int32",
+					"example": "15",
+					"description": "Tempo de experiência profissional na área de interesse 1",
+					"x-totvs": [
+						{
+							"product": "Protheus",
+							"field": "",
+							"required": false,
+							"type": "integer",
+							"available": true,
+							"canUpdate": false,
+							"note":""
+						},
+						{
+							"product": "RM",
+							"field": "VCANDIDATOS.EXPERIENCIAAREACURR1",
+							"required": false,
+							"type": "int",
+							"available": true,
+							"canUpdate": true
+						},
+						{
+							"product": "DATASUL",
+							"field": "EMPRES_ANT_CANDIDATO_EXT.NUM_MESES_TRABDO_CANDEMPR",
+							"type": "integer",
+							"required": false,
+							"available": false,							
+							"note": "Campo do sistema ainda não implementado na API."
+						}
+					]
+				},
+				"workExperienceTimeArea2": {
+					"type": "integer",
+					"format": "int32",
+					"example": "15",
+					"description": "Tempo de experiência profissional na área de interesse 2",
+					"x-totvs": [
+						{
+							"product": "Protheus",
+							"field": "",
+							"required": false,
+							"type": "integer",
+							"available": true,
+							"canUpdate": false,
+							"note":""
+						},
+						{
+							"product": "RM",
+							"field": "VCANDIDATOS.EXPERIENCIAAREACURR1",
+							"required": false,
+							"type": "int",
+							"available": true,
+							"canUpdate": true
+						},
+						{
+							"product": "DATASUL",
+							"field": "EMPRES_ANT_CANDIDATO_EXT.NUM_MESES_TRABDO_CANDEMPR",
+							"type": "integer",
+							"required": false,
+							"available": false,							
+							"note": "Campo do sistema ainda não implementado na API."
+						}
+					]
+				},
+				"contraIndicated": {
+					"type": "integer",
+					"format": "int16",
+					"example": "1",
+					"description": "É contraindicado?",
+					"x-totvs": [
+						{
+							"product": "Protheus",
+							"field": "",
+							"required": false,
+							"type": "varchar",
+							"available": true,
+							"canUpdate": false,
+							"note":""
+						},
+						{
+							"product": "RM",
+							"field": "VCANDIDATOS.CONTRAINDICADO",
+							"required": false,
+							"type": "smallint",
+							"available": true,
+							"canUpdate": true
+						},
+						{
+							"product": "DATASUL",
+							"field": "CANDIDATO_EXT.IDI_SIT_CANDEMPR",
+							"type": "integer",
+							"required": false,
+							"available": false,
+							"note": "3 = Impedido. Campo do sistema ainda não implementado na API."
+						}
+					]
+				},
+				"contraindicationReason": {
+					"type": "string",
+					"description": "Razão da contraindicação",
+					"x-totvs": [
+						{
+							"product": "Protheus",
+							"field": "",
+							"required": false,
+							"type": "varchar",
+							"available": true,
+							"canUpdate": false,
+							"note":""
+						},
+						{
+							"product": "RM",
+							"field": "VCANDIDATOS.MOTIVOCONTRAINDICACAO",
+							"length": "120",
+							"required": false,
+							"type": "varchar",
+							"available": true
+						},
+						{
+							"product": "DATASUL",
+							"field": "CANDIDATO_EXT.DSL_OBS_RECRUT_CANDEMPR",
+							"type": "string",
+							"required": false,
+							"available": false,							
+							"note": "Campo do sistema ainda não implementado na API."
+						}
+					]
+				},
+				"available": {
+					"type": "integer",
+					"format": "int16",
+					"example": "1",
+					"description": "Que participar do processo seletivo?",
+					"x-totvs": [
+						{
+							"product": "Protheus",
+							"field": "",
+							"required": false,
+							"type": "integer",
+							"available": true,
+							"canUpdate": false,
+							"note":""
+						},
+						{
+							"product": "RM",
+							"field": "VCANDIDATOS.DISPONIVEL",
+							"required": false,
+							"type": "smallint",
+							"available": true,
+							"canUpdate": true
+						},
+						{
+							"product": "DATASUL",
+							"field": "AGENDA_REQ_PESSOAL.IDI_SIT_CANDEMPR_AGENDA_REQ",
+							"type": "string",
+							"required": false,
+							"available": false,							
+							"note": "Campo do sistema ainda não implementado na API."
+						}
+					]
+				},
+				"formOfRecruitment": {
+					"type": "string",
+					"description": "Forma de contratação",
+					"x-totvs": [
+						{
+							"product": "Protheus",
+							"field": "",
+							"required": false,
+							"type": "varchar",
+							"available": true,
+							"canUpdate": false,
+							"note":""
+						},
+						{
+							"product": "RM",
+							"field": "VCANDIDATOS.CODPERFILCURR",
+							"length": "2",
+							"required": false,
+							"type": "varchar",
+							"available": true
+						},
+						{
+							"product": "DATASUL",
+							"field": "CANDIDATO_EXT.IDI_TIP_VAGA",
+							"type": "integer",
+							"required": false,
+							"available": false,							
+							"note": "Campo do sistema ainda não implementado na API."
+						}
+					]
+				},
+				"resumeSkillsId": {
+					"type": "integer",
+					"format": "int32",
+					"example": "15",
+					"description": "ID do resumo da qualificação do candidato",
+					"x-totvs": [
+						{
+							"product": "Protheus",
+							"field": "",
+							"required": false,
+							"type": "varchar",
+							"available": true,
+							"canUpdate": false,
+							"note":""
+						},
+						{
+							"product": "RM",
+							"field": "VCANDIDATOS.IDRESUMOQUALIF",
+							"required": false,
+							"type": "int",
+							"available": true,
+							"canUpdate": true
+						},
+						{
+							"product": "DATASUL",
+							"field": "",
+							"type": "string",
+							"required": false,
+							"available": true
+						}
+					]
+				},
+				"hierarchyLevelCode": {
+					"type": "integer",
+					"format": "int32",
+					"example": "15",
+					"description": "Código do nível hierárquico",
+					"x-totvs": [
+						{
+							"product": "Protheus",
+							"field": "SQGXX0.QG_NIVHIER",
+							"required": false,
+							"type": "varchar",
+							"available": true,
+							"canUpdate": false,
+							"note":""
+						},
+						{
+							"product": "RM",
+							"field": "VCANDIDATOS.CODNIVELHIERARQUICO",
+							"required": false,
+							"type": "int",
+							"available": true,
+							"canUpdate": true
+						},
+						{
+							"product": "DATASUL",
+							"field": "CARGO_INDCAO_RECRUT.CDN_CARGO_BASIC + - + CARGO_INDCAO_RECRUT.CDN_NIV_CARGO",
+							"type": "string",
+							"required": false,
+							"available": false,							
+							"note": "Campo do sistema ainda não implementado na API."
+						}
+					]
+				},
+				"professionalProfileDescription": {
+					"type": "string",
+					"description": "Descrição do perfil profissional",
+					"x-totvs": [
+						{
+							"product": "Protheus",
+							"field": "",
+							"required": false,
+							"type": "varchar",
+							"available": true,
+							"canUpdate": false,
+							"note":""
+						},
+						{
+							"product": "RM",
+							"field": "VPERFILCURRIC.DESCRICAO",
+							"length": "50",
+							"required": false,
+							"type": "varchar",
+							"available": true
+						},
+						{
+							"product": "DATASUL",
+							"field": "CANDIDATO_EXT.DSL_OBS_RECRUT_CANDEMPR",
+							"type": "string",
+							"required": false,
+							"available": false,							
+							"note": "Campo do sistema ainda não implementado na API."
+						}
+					]
+				},
+				"areaOfInterestDescription1": {
+					"type": "string",
+					"description": "Descrição da áre de interesse 1",
+					"x-totvs": [
+						{
+							"product": "Protheus",
+							"field": "",
+							"required": false,
+							"type": "varchar",
+							"available": true,
+							"canUpdate": false,
+							"note":""
+						},
+						{
+							"product": "RM",
+							"field": "VAREACURRICULAR.NOME",
+							"length": "80",
+							"required": false,
+							"type": "varchar",
+							"available": true
+						},
+						{
+							"product": "DATASUL",
+							"field": "CANDIDATO_EXT_AREA_INTERES.NOM_RAMO_ATIVID",
+							"type": "string",
+							"required": false,
+							"available": false,							
+							"note": "Campo do sistema ainda não implementado na API.",
+							"length": "30"
+						}
+					]
+				},
+				"areaOfInterestDescription2": {
+					"type": "string",
+					"description": "Descrição da áre de interesse 2",
+					"x-totvs": [
+						{
+							"product": "Protheus",
+							"field": "",
+							"required": false,
+							"type": "varchar",
+							"available": true,
+							"canUpdate": false,
+							"note":""
+						},
+						{
+							"product": "RM",
+							"field": "VAREACURRICULAR2.NOME",
+							"length": "80",
+							"required": false,
+							"type": "varchar",
+							"available": true
+						},
+						{
+							"product": "DATASUL",
+							"field": "CANDIDATO_EXT_AREA_INTERES.NOM_RAMO_ATIVID",
+							"type": "string",
+							"required": false,
+							"available": false,							
+							"note": "Campo do sistema ainda não implementado na API.",
+							"length": "30"
+						}
+					]
+				},
+				"hierarchyLevelDescription": {
+					"type": "string",
+					"description": "Descrição do nível hierárquico",
+					"x-totvs": [
+						{
+							"product": "Protheus",
+							"field": "",
+							"required": false,
+							"type": "varchar",
+							"available": true,
+							"canUpdate": false,
+							"note":""
+						},
+						{
+							"product": "RM",
+							"field": "VNIVELHIERARQUICO.DESCRICAO",
+							"length": "60",
+							"required": false,
+							"type": "varchar",
+							"available": true
+						},
+						{
+							"product": "DATASUL",
+							"field": "",
+							"type": "string",
+							"required": false,
+							"available": true
+						}
+					]
+				},
+				"professionalSkillsResumeDescription": {
+					"type": "string",
+					"description": "Descrição do resumo de qualificações",
+					"x-totvs": [
+						{
+							"product": "Protheus",
+							"field": "SQGXX0.QG_MEMO2",
+							"required": false,
+							"type": "varchar",
+							"available": true,
+							"canUpdate": false,
+							"note":""
+						},
+						{
+							"product": "RM",
+							"field": "VMEMO.VALMEMO",
+							"length": "10000",
+							"required": false,
+							"type": "varchar",
+							"available": true
+						},
+						{
+							"product": "DATASUL",
+							"field": "CANDIDATO_EXT.DSL_OBS_RECRUT_CANDEMPR",
+							"type": "string",
+							"required": false,
+							"available": false,							
+							"note": "Campo do sistema ainda não implementado na API."
+						}
+					]
+				},
+				"employee1": {
+					"type": "string",
+					"description": "Funcionário",
+					"x-totvs": [
+						{
+							"product": "Protheus",
+							"field": "",
+							"required": false,
+							"type": "varchar",
+							"available": true,
+							"canUpdate": false,
+							"note":""
+						},
+						{
+							"product": "RM",
+							"required": false,
+							"type": "varchar",
+							"available": true
+						},
+						{
+							"product": "DATASUL",
+							"field": "",
+							"type": "string",
+							"required": false,
+							"available": true
+						}
+					]
+				},
+				"personalEmail": {
+					"type": "string",
+					"description": "Email Pessoal",
+					"x-totvs": [
+						{
+							"product": "Protheus",
+							"field": "",
+							"required": false,
+							"type": "varchar",
+							"available": true,
+							"canUpdate": false,
+							"note":""
+						},
+						{
+							"product": "RM",
+							"field": "PPESSOA.EMAILPESSOAL",
+							"length": "60",
+							"required": false,
+							"type": "varchar",
+							"available": true
+						},
+						{
+							"product": "DATASUL",
+							"field": "RH_PESSOA_FISIC.NOM_MAIL_CONTAT",
+							"type": "string",
+							"required": false,
+							"available": true
+						}
+					]
+				},
+				"maritalState": {
+					"type": "string",
+					"description": "Estado Civil",
+					"x-totvs": [
+						{
+							"product": "Protheus",
+							"field": "SQGXX0.QG_ESTCIV",
+							"required": false,
+							"type": "varchar",
+							"available": true,
+							"canUpdate": false,
+							"note":"C=Casado;S=Solteiro,D=Divorciado;M=Uniao Estavel;Q=Desquitado;V=Viuvo"
+						},
+						{
+							"product": "RM",
+							"field": "PPESSOA.ESTADOCIVIL",
+							"length": "1",
+							"required": false,
+							"type": "varchar",
+							"available": true
+						},
+						{
+							"product": "DATASUL",
+							"field": "CANDIDATO_EXT.IDI_ESTADO_CIVIL",
+							"type": "integer",
+							"required": false,
+							"available": false,							
+							"note": "Campo do sistema ainda não implementado na API."
+						}
+					]
+				},
+				"complement": {
+					"type": "string",
+					"description": "Estado Civil",
+					"x-totvs": [
+						{
+							"product": "Protheus",
+							"field": "",
+							"required": false,
+							"type": "varchar",
+							"available": true,
+							"canUpdate": false,
+							"note":""
+						},
+						{
+							"product": "RM",
+							"field": "PPESSOA.COMPLEMENTO",
+							"length": "60",
+							"required": false,
+							"type": "varchar",
+							"available": true
+						},
+						{
+							"product": "DATASUL",
+							"field": "",
+							"type": "string",
+							"required": false,
+							"available": true
+						}
+					]
+				},
+				"arrivalDate": {
+					"type": "date",
+					"format": "date-time",
+					"example": "1975-05-26 00:00:00",
+					"description": "Data de Chegada ao Brasil",
+					"x-totvs": [
+						{
+							"product": "Protheus",
+							"field": "",
+							"required": false,
+							"type": "datetime",
+							"available": true,
+							"canUpdate": false,
+							"note":""
+						},
+						{
+							"product": "RM",
+							"field": "PPESSOA.DATACHEGADA",
+							"required": false,
+							"type": "datetime",
+							"available": true,
+							"canUpdate": true
+						},
+						{
+							"product": "DATASUL",
+							"field": "DOCUMEN_CANDEMPR.NUM_ANO_CHEGAD_PAIS",
+							"type": "integer",
+							"required": false,
+							"available": false,							
+							"note": "Campo do sistema ainda não implementado na API."
+						}
+					]
+				},
+				"letterModel19": {
+					"type": "string",
+					"description": "Carta modelo 19",
+					"x-totvs": [
+						{
+							"product": "Protheus",
+							"field": "",
+							"required": false,
+							"type": "varchar",
+							"available": true,
+							"canUpdate": false,
+							"note":""
+						},
+						{
+							"product": "RM",
+							"field": "PPESSOA.CARTMODELO19",
+							"length": "15",
+							"required": false,
+							"type": "varchar",
+							"available": true
+						},
+						{
+							"product": "DATASUL",
+							"field": "",
+							"type": "string",
+							"required": false,
+							"available": true
+						}
+					]
+				},
+				"rne": {
+					"type": "string",
+					"description": "Registro Geral - RNE",
+					"x-totvs": [
+						{
+							"product": "Protheus",
+							"field": "",
+							"required": false,
+							"type": "varchar",
+							"available": true,
+							"canUpdate": false,
+							"note":""
+						},
+						{
+							"product": "RM",
+							"field": "PPESSOA.NROREGGERAL",
+							"length": "15",
+							"required": false,
+							"type": "varchar",
+							"available": true
+						},
+						{
+							"product": "DATASUL",
+							"field": "DOCUMEN_CANDEMPR.COD_IDENTDE_ESTRANG",
+							"type": "string",
+							"required": false,
+							"available": false,							
+							"note": "Campo do sistema ainda não implementado na API."
+						}
+					]
+				},
+				"immigrationDecree": {
+					"type": "string",
+					"description": "Decreto de Imigração",
+					"x-totvs": [
+						{
+							"product": "Protheus",
+							"field": "",
+							"required": false,
+							"type": "varchar",
+							"available": true,
+							"canUpdate": false,
+							"note":""
+						},
+						{
+							"product": "RM",
+							"field": "PPESSOA.NRODECRETO",
+							"length": "15",
+							"required": false,
+							"type": "varchar",
+							"available": true
+						},
+						{
+							"product": "DATASUL",
+							"field": "",
+							"type": "string",
+							"required": false,
+							"available": false,							
+							"note": "Campo do sistema ainda não implementado na API."
+						}
+					]
+				},
+				"rneExpirationDate": {
+					"type": "date",
+					"format": "date-time",
+					"example": "1975-05-26 00:00:00",
+					"description": "Data de Venc. RNE",
+					"x-totvs": [
+						{
+							"product": "Protheus",
+							"field": "",
+							"required": false,
+							"type": "datetime",
+							"available": true,
+							"canUpdate": false,
+							"note":""
+						},
+						{
+							"product": "RM",
+							"field": "PPESSOA.DTVENCIDENT",
+							"required": false,
+							"type": "datetime",
+							"available": true,
+							"canUpdate": true
+						},
+						{
+							"product": "DATASUL",
+							"field": "DOCUMEN_CANDEMPR.DAT_VALID_IDENT_ESTRANG",
+							"type": "string",
+							"required": false,
+							"available": false,							
+							"note": "Campo do sistema ainda não implementado na API."							
+						}
+					]
+				},
+				"workCardExpirationDate": {
+					"type": "date",
+					"format": "date-time",
+					"example": "1975-05-26 00:00:00",
+					"description": "Data de Venc. Carteira Trabalho",
+					"x-totvs": [
+						{
+							"product": "Protheus",
+							"field": "",
+							"required": false,
+							"type": "datetime",
+							"available": true,
+							"canUpdate": false,
+							"note":""
+						},
+						{
+							"product": "RM",
+							"field": "PPESSOA.DTVENCIDENT",
+							"required": false,
+							"type": "datetime",
+							"available": true,
+							"canUpdate": true
+						},
+						{
+							"product": "DATASUL",
+							"field": "",
+							"type": "string",
+							"required": false,
+							"available": true
+						}
+					]
+				},
+				"visaType": {
+					"type": "string",
+					"description": "Tipo de Visto",
+					"x-totvs": [
+						{
+							"product": "Protheus",
+							"field": "",
+							"required": false,
+							"type": "varchar",
+							"available": true,
+							"canUpdate": false,
+							"note":""
+						},
+						{
+							"product": "RM",
+							"field": "PPESSOA.TIPOVISTO",
+							"length": "10",
+							"required": false,
+							"type": "varchar",
+							"available": true
+						},
+						{
+							"product": "DATASUL",
+							"field": "DOCUMEN_CANDEMPR.IDI_TIP_VISTO_ESTRANG",
+							"type": "string",
+							"required": false,
+							"available": false,							
+							"note": "Campo do sistema ainda não implementado na API."
+						}
+					]
+				},
+				"passportNumber": {
+					"type": "string",
+					"description": "Número do Passaporte",
+					"x-totvs": [
+						{
+							"product": "Protheus",
+							"field": "",
+							"required": false,
+							"type": "varchar",
+							"available": true,
+							"canUpdate": false,
+							"note":""
+						},
+						{
+							"product": "RM",
+							"field": "PPESSOA.NPASSAPORTE",
+							"length": "15",
+							"required": false,
+							"type": "varchar",
+							"available": true
+						},
+						{
+							"product": "DATASUL",
+							"field": "COMPL_PESSOA_FISIC.COD_PASPORTE",
+							"type": "string",
+							"required": false,
+							"available": false,							
+							"note": "Campo do sistema ainda não implementado na API."
+						}
+					]
+				},
+				"nativeCountry": {
+					"type": "string",
+					"description": "País de origem",
+					"x-totvs": [
+						{
+							"product": "Protheus",
+							"field": "",
+							"required": false,
+							"type": "varchar",
+							"available": true,
+							"canUpdate": false,
+							"note":""
+						},
+						{
+							"product": "RM",
+							"field": "PPESSOA.PAISORIGEM",
+							"length": "20",
+							"required": false,
+							"type": "varchar",
+							"available": true
+						},
+						{
+							"product": "DATASUL",
+							"field": "COMPL_PESSOA_FISIC.COD_PAIS_EMIS_PASPORTE",
+							"type": "string",
+							"required": false,
+							"available": false,							
+							"note": "Campo do sistema ainda não implementado na API."
+						}
+					]
+				},
+				"passportExpirationDate": {
+					"type": "date",
+					"format": "date-time",
+					"example": "1975-05-26 00:00:00",
+					"description": "Data Validade Passaporte",
+					"x-totvs": [
+						{
+							"product": "Protheus",
+							"field": "",
+							"required": false,
+							"type": "datetime",
+							"available": true,
+							"canUpdate": false,
+							"note":""
+						},
+						{
+							"product": "RM",
+							"field": "PPESSOA.DTVALPASSAPORTE",
+							"required": false,
+							"type": "datetime",
+							"available": true,
+							"canUpdate": true
+						},
+						{
+							"product": "DATASUL",
+							"field": "COMPL_PESSOA_FISIC.DAT_VALID_PASPORTE",
+							"type": "date",
+							"required": false,
+							"available": false,							
+							"note": "Campo do sistema ainda não implementado na API."
+						}
+					]
+				},
+				"accessibilityFeaturesForJobLocal": {
+					"type": "string",
+					"description": "Recursos p/ acessibilidade ao local de trabalho",
+					"x-totvs": [
+						{
+							"product": "Protheus",
+							"field": "",
+							"required": false,
+							"type": "varchar",
+							"available": true,
+							"canUpdate": false,
+							"note":""
+						},
+						{
+							"product": "RM",
+							"field": "PPESSOA.RECURSOACESSIBILIDADE",
+							"length": "120",
+							"required": false,
+							"type": "varchar",
+							"available": true
+						},
+						{
+							"product": "DATASUL",
+							"field": "",
+							"type": "string",
+							"required": false,
+							"available": true
+						}
+					]
+				},
+				"militaryDivision": {
+					"type": "string",
+					"description": "CSM",
+					"x-totvs": [
+						{
+							"product": "Protheus",
+							"field": "",
+							"required": false,
+							"type": "varchar",
+							"available": true,
+							"canUpdate": false,
+							"note":""
+						},
+						{
+							"product": "RM",
+							"field": "PPESSOA.CSM",
+							"length": "10",
+							"required": false,
+							"type": "varchar",
+							"available": true
+						},
+						{
+							"product": "DATASUL",
+							"field": "DOCUMEN_CANDEMPR.CDN_CIRCUNS_MILIT",
+							"type": "integer",
+							"required": false,
+							"available": false,							
+							"note": "Campo do sistema ainda não implementado na API."
+						}
+					]
+				},
+				"militaryCertificateEmissionDate": {
+					"type": "date",
+					"format": "date-time",
+					"example": "1975-05-26 00:00:00",
+					"description": "Data Emissão C.Militar",
+					"x-totvs": [
+						{
+							"product": "Protheus",
+							"field": "",
+							"required": false,
+							"type": "datetime",
+							"available": true,
+							"canUpdate": false,
+							"note":""
+						},
+						{
+							"product": "RM",
+							"field": "PPESSOA.DTEXPCML",
+							"required": false,
+							"type": "datetime",
+							"available": true,
+							"canUpdate": true
+						},
+						{
+							"product": "DATASUL",
+							"field": "",
+							"type": "string",
+							"required": false,
+							"available": true
+						}
+					]
+				},
+				"militaryCertificateEmitterAgency": {
+					"type": "string",
+					"description": "Orgão de Expedição",
+					"x-totvs": [
+						{
+							"product": "Protheus",
+							"field": "",
+							"required": false,
+							"type": "datetime",
+							"available": true,
+							"canUpdate": false,
+							"note":""
+						},
+						{
+							"product": "RM",
+							"field": "PPESSOA.EXPED",
+							"required": false,
+							"type": "datetime",
+							"available": true,
+							"canUpdate": true
+						},
+						{
+							"product": "DATASUL",
+							"field": "",
+							"type": "string",
+							"required": false,
+							"available": true
+						}
+					]
+				},
+				"militaryRegion": {
+					"type": "string",
+					"description": "Região militar",
+					"x-totvs": [
+						{
+							"product": "Protheus",
+							"field": "",
+							"required": false,
+							"type": "varchar",
+							"available": true,
+							"canUpdate": false,
+							"note":""
+						},
+						{
+							"product": "RM",
+							"field": "PPESSOA.RM",
+							"length": "10",
+							"required": false,
+							"type": "varchar",
+							"available": true
+						},
+						{
+							"product": "DATASUL",
+							"field": "DOCUMEN_CANDEMPR.CDN_REGIAO_MILIT",
+							"type": "integer",
+							"required": false,
+							"available": false,							
+							"note": "Campo do sistema ainda não implementado na API."
+						}
+					]
+				},
+				"militarySituation": {
+					"type": "string",
+					"description": "Situação Militar",
+					"x-totvs": [
+						{
+							"product": "Protheus",
+							"field": "",
+							"required": false,
+							"type": "varchar",
+							"available": true,
+							"canUpdate": false,
+							"note":""
+						},
+						{
+							"product": "RM",
+							"field": "PPESSOA.SITMILITAR",
+							"length": "10",
+							"required": false,
+							"type": "varchar",
+							"available": true
+						},
+						{
+							"product": "DATASUL",
+							"field": "",
+							"type": "integer",
+							"required": false,
+							"available": true
+						}
+					]
+				},
+				"electoralCardEmitterState": {
+					"type": "string",
+					"description": "Est. Emissor Tit. Eleitor",
+					"x-totvs": [
+						{
+							"product": "Protheus",
+							"field": "",
+							"required": false,
+							"type": "varchar",
+							"available": true,
+							"canUpdate": false,
+							"note":""
+						},
+						{
+							"product": "RM",
+							"field": "PPESSOA.ESTELEIT",
+							"length": "2",
+							"required": false,
+							"type": "varchar",
+							"available": true
+						},
+						{
+							"product": "DATASUL",
+							"field": "DOCUMEN_CANDEMPR.COD_UNID_FEDERAC_TIT_ELETRAL",
+							"type": "string",
+							"required": false,
+							"available": false,							
+							"note": "Campo do sistema ainda não implementado na API."
+						}
+					]
+				},
+				"bloodType": {
+					"type": "string",
+					"description": "Tipo sanguíneo",
+					"x-totvs": [
+						{
+							"product": "Protheus",
+							"field": "",
+							"required": false,
+							"type": "varchar",
+							"available": true,
+							"canUpdate": false,
+							"note":""
+						},
+						{
+							"product": "RM",
+							"field": "PPESSOA.TIPOSANG",
+							"length": "10",
+							"required": false,
+							"type": "varchar",
+							"available": true
+						},
+						{
+							"product": "DATASUL",
+							"field": "CANDIDATO_EXT.IDI_TIP_SANGUE",
+							"type": "integer",
+							"required": false,
+							"available": false,							
+							"note": "Campo do sistema ainda não implementado na API."
+						}
+					]
+				},
+				"image": {
+					"type": "string",
+					"format": "byte",
+					"description": "Imagem",
+					"x-totvs": [
+						{
+							"product": "Protheus",
+							"field": "",
+							"required": false,
+							"type": "varchar",
+							"available": true,
+							"canUpdate": false,
+							"note":""
+						},
+						{
+							"product": "RM",
+							"field": "GIMAGEM.IMAGEM",
+							"required": false,
+							"type": "DIMAGEM",
+							"available": true
+						},
+						{
+							"product": "DATASUL",
+							"field": "CANDIDATO_EXT.COD_IMAGEM",
+							"type": "string",
+							"required": false,
+							"available": false,							
+							"note": "Campo do sistema ainda não implementado na API."
+						}
+					]
+				},
+				"neighborhoodTypeCode": {
+					"type": "integer",
+					"format": "int16",
+					"example": "15",
+					"description": "Cód. Tipo Bairro",
+					"x-totvs": [
+						{
+							"product": "Protheus",
+							"field": "",
+							"required": false,
+							"type": "varchar",
+							"available": true,
+							"canUpdate": false,
+							"note":""
+						},
+						{
+							"product": "RM",
+							"field": "PPESSOA.CODTIPOBAIRRO",
+							"required": false,
+							"type": "smallint",
+							"available": true,
+							"canUpdate": true
+						},
+						{
+							"product": "DATASUL",
+							"field": "",
+							"type": "string",
+							"required": false,
+							"available": true
+						}
+					]
+				},
+				"naturalnessCode": {
+					"type": "string",
+					"description": "Tipo sanguíneo",
+					"x-totvs": [
+						{
+							"product": "Protheus",
+							"field": "",
+							"required": false,
+							"type": "varchar",
+							"available": true,
+							"canUpdate": false,
+							"note":""
+						},
+						{
+							"product": "RM",
+							"field": "PPESSOA.CODNATURALIDADE",
+							"length": "20",
+							"required": false,
+							"type": "varchar",
+							"available": true
+						},
+						{
+							"product": "DATASUL",
+							"field": "",
+							"type": "string",
+							"required": false,
+							"available": true
+						}
+					]
+				},
+				"naturalisationDate": {
+					"type": "date",
+					"format": "date-time",
+					"example": "1975-05-26 00:00:00",
+					"description": "Data de Naturalização",
+					"x-totvs": [
+						{
+							"product": "Protheus",
+							"field": "",
+							"required": false,
+							"type": "datetime",
+							"available": true,
+							"canUpdate": false,
+							"note":""
+						},
+						{
+							"product": "RM",
+							"field": "PPESSOA.CODNATURALIDADE",
+							"required": false,
+							"type": "datetime",
+							"available": true,
+							"canUpdate": true
+						},
+						{
+							"product": "DATASUL",
+							"field": "COMPL_PESSOA_FISIC.DAT_NATURALIZ",
+							"type": "date",
+							"required": false,
+							"available": false,							
+							"note": "Campo do sistema ainda não implementado na API."
+						}
+					]
+				},
+				"driversLicenseEmitterAgency": {
+					"type": "string",
+					"description": "Orgão Emissor CNH",
+					"x-totvs": [
+						{
+							"product": "Protheus",
+							"field": "",
+							"required": false,
+							"type": "varchar",
+							"available": true,
+							"canUpdate": false,
+							"note":""
+						},
+						{
+							"product": "RM",
+							"field": "PPESSOA.ORGEMISSORCNH",
+							"length": "20",
+							"required": false,
+							"type": "varchar",
+							"available": true,
+							"canUpdate": true
+						},
+						{
+							"product": "DATASUL",
+							"field": "",
+							"type": "string",
+							"required": false,
+							"available": true
+						}
+					]
+				},
+				"rneEmitterAgency": {
+					"type": "string",
+					"description": "Orgão e UF Emissor RNE",
+					"x-totvs": [
+						{
+							"product": "Protheus",
+							"field": "",
+							"required": false,
+							"type": "varchar",
+							"available": true,
+							"canUpdate": false,
+							"note":""
+						},
+						{
+							"product": "RM",
+							"field": "PPESSOA.ORGEMISSORRNE",
+							"length": "20",
+							"required": false,
+							"type": "varchar",
+							"available": true,
+							"canUpdate": true
+						},
+						{
+							"product": "DATASUL",
+							"field": "",
+							"type": "string",
+							"required": false,
+							"available": true
+						}
+					]
+				},
+				"countryId": {
+					"type": "integer",
+					"format": "int16",
+					"example": "1",
+					"description": "Id Pais",
+					"x-totvs": [
+						{
+							"product": "Protheus",
+							"field": "",
+							"required": false,
+							"type": "varchar",
+							"available": true,
+							"canUpdate": false,
+							"note":""
+						},
+						{
+							"product": "RM",
+							"field": "PPESSOA.IDPAIS",
+							"required": false,
+							"type": "smallint",
+							"available": true,
+							"canUpdate": true
+						},
+						{
+							"product": "DATASUL",
+							"field": "CANDIDATO_EXT.COD_PAIS_NASCIMENTO",
+							"type": "string",
+							"required": false,
+							"available": false,							
+							"note": "Campo do sistema ainda não implementado na API." 
+						}
+					]
+				},
+				"deceaseDate": {
+					"type": "date",
+					"format": "date-time",
+					"example": "1975-05-26 00:00:00",
+					"description": "Data de falecimento",
+					"x-totvs": [
+						{
+							"product": "Protheus",
+							"field": "",
+							"required": false,
+							"type": "datetime",
+							"available": true,
+							"canUpdate": false,
+							"note":""
+						},
+						{
+							"product": "RM",
+							"field": "PPESSOA.DATAOBITO",
+							"required": false,
+							"type": "datetime",
+							"available": true,
+							"canUpdate": true
+						},
+						{
+							"product": "DATASUL",
+							"field": "COMPL_PESSOA_FISIC.DAT_LIVRE_1",
+							"type": "string",
+							"required": false,
+							"available": false,							
+							"note": "Campo do sistema ainda não implementado na API."
+						}
+					]
+				},
+				"deathCertificateNumber": {
+					"type": "string",
+					"description": "Matrícula da Certidão de Óbito",
+					"x-totvs": [
+						{
+							"product": "Protheus",
+							"field": "",
+							"required": false,
+							"type": "varchar",
+							"available": true,
+							"canUpdate": false,
+							"note":""
+						},
+						{
+							"product": "RM",
+							"field": "PPESSOA.MATRICULAOBITO",
+							"length": "50",
+							"required": false,
+							"type": "varchar",
+							"available": true,
+							"canUpdate": true
+						},
+						{
+							"product": "DATASUL",
+							"field": "COMPL_PESSOA_FISIC.COD_MATR_CERTID",
+							"type": "string",
+							"required": false,
+							"available": false,							
+							"note": "Campo do sistema ainda não implementado na API."
+						}
+					]
+				},
+				"naturalisationGatehouse": {
+					"type": "string",
+					"description": "Portaria de Naturalização",
+					"x-totvs": [
+						{
+							"product": "Protheus",
+							"field": "",
+							"required": false,
+							"type": "varchar",
+							"available": true,
+							"canUpdate": false,
+							"note":""
+						},
+						{
+							"product": "RM",
+							"field": "PPESSOA.PORTARIANATURALIZACAO",
+							"length": "50",
+							"required": false,
+							"type": "varchar",
+							"available": true,
+							"canUpdate": true
+						},
+						{
+							"product": "DATASUL",
+							"field": "COMPL_PESSOA_FISIC.COD_PORTARIA_NATURALIZ",
+							"type": "string",
+							"required": false,
+							"available": false,							
+							"note": "Campo do sistema ainda não implementado na API." 
+						}
+					]
+				},
+				"brazilConditionClassification": {
+					"type": "string",
+					"description": "Portaria de Naturalização",
+					"x-totvs": [
+						{
+							"product": "Protheus",
+							"field": "",
+							"required": false,
+							"type": "varchar",
+							"available": true,
+							"canUpdate": false,
+							"note":""
+						},
+						{
+							"product": "RM",
+							"field": "PPESSOA.CODCLASSIFTRABESTRANG",
+							"length": "20",
+							"required": false,
+							"type": "varchar",
+							"available": true,
+							"canUpdate": true
+						},
+						{
+							"product": "DATASUL",
+							"field": "COMPL_PESSOA_FISIC.IDI_COND_TRABDOR_ESTRANG",
+							"type": "string",
+							"required": false,
+							"available": false,							
+							"note": "Campo do sistema ainda não implementado na API."
+						}
+					]
+				},
+				"driversLicenseFirstEmissionDate": {
+					"type": "date",
+					"format": "date-time",
+					"example": "1975-05-26 00:00:00",
+					"description": "Data Primeira CNH",
+					"x-totvs": [
+						{
+							"product": "Protheus",
+							"field": "",
+							"required": false,
+							"type": "datetime",
+							"available": true,
+							"canUpdate": false,
+							"note":""
+						},
+						{
+							"product": "RM",
+							"field": "PPESSOA.DATAPRIMEIRACNH",
+							"required": false,
+							"type": "datetime",
+							"available": true,
+							"canUpdate": true
+						},
+						{
+							"product": "DATASUL",
+							"field": "DOCUMEN_CANDEMPR.DAT_EMIS_CART_HABILIT",
+							"type": "string",
+							"required": false,
+							"available": false,							
+							"note": "Campo do sistema ainda não implementado na API."
+						}
+					]
+				},
+				"firstJobYear": {
+					"type": "integer",
+					"format": "int32",
+					"example": "15",
+					"description": "Ano do Primeiro Emprego",
+					"x-totvs": [
+						{
+							"product": "Protheus",
+							"field": "",
+							"required": false,
+							"type": "varchar",
+							"available": true,
+							"canUpdate": false,
+							"note":""
+						},
+						{
+							"product": "RM",
+							"field": "PPESSOA.ANO1EMPREGO",
+							"required": false,
+							"type": "int",
+							"available": true,
+							"canUpdate": true
+						},
+						{
+							"product": "DATASUL",
+							"field": "",
+							"type": "string",
+							"required": false,
+							"available": true
+						}
+					]
+				}
+			}
+		}
+	}
+}


### PR DESCRIPTION
Criação da v2 da API de candidatos uma vez que ocorreram mudanças que exigem uma nova versão maior, como:

→ Parâmetros obrigatórios adicionados 
→ Parâmetros renomeados 
→ Propriedades do schema ou renomeadas  

Atualização de outros produtos:
→ Inclusão de De-Para do Protheus e atualização do método que o Protheus tem disponível na api.  
→ Criação do DE-PARA da api de candidatos V2 dos campos do Datasul.