### PR TITLE
 RetailPriceList/v1/2_006

### DIFF
--- a/jsonschema/apis/RetailPriceList_v1_000.json
+++ b/jsonschema/apis/RetailPriceList_v1_000.json
@@ -31,7 +31,7 @@
       },
       "productInformation": [
         {
-          "product": "protheus",
+          "product": "Protheus",
           "contact": "rafael.tenorio@totvs.com.br",
           "description": "Consulta de Preços - Varejo",
           "adapter": "",
@@ -50,7 +50,7 @@
         "x-totvs": {
           "productInformation": [
             {
-              "product": "protheus",
+              "product": "Protheus",
               "available": true,
               "note": "Este verbo esta disponível com todos os parâmetros.",
               "minimalVersion": "12.1.23"
@@ -115,7 +115,7 @@
         "x-totvs": {
           "productInformation": [
             {
-              "product": "protheus",
+              "product": "Protheus",
               "available": true,
               "note": "Este verbo está disponível com os parâmetros Authorization, Order, Fields e InternalId.",
               "minimalVersion": "12.1.23"
@@ -175,7 +175,7 @@
         "x-totvs": {
           "productInformation": [
             {
-              "product": "protheus",
+              "product": "Protheus",
               "available": true,
               "note": "Este verbo esta disponível com todos os parâmetros.",
               "minimalVersion": "12.1.23"

--- a/jsonschema/apis/RetailPriceList_v1_000.json
+++ b/jsonschema/apis/RetailPriceList_v1_000.json
@@ -1,942 +1,942 @@
 {
-	"openapi": "3.0.1",
-	"servers": [
-		{
-			"description": "API para cadastro tabela de preços dos produtos TOTVS Varejo",
-			"url": "http://{serverUrl}:{serverHttpPort}/api/retail/v1",
-			"variables": {
-				"serverUrl": {
-					"default": "localhost"
-				},
-				"serverHttpPort": {
-					"default": "8051"
-				}
-			}
-		}
-	],
-	"info": {
-		"description": "API para manutenção de tabela de preço para os produtos TOTVS Varejo",
-		"version": "1.000",
-		"title": "Tabela de Preços Varejo",
-		"contact": {
-			"name": "T-Talk",
-			"url": "api.totvs.com.br",
-			"email": "comiteintegracao@totvs.com.br"
-		},
-		"x-totvs": {
-			"messageDocumentation": {
-				"name": "RetailPriceList",
-				"descriotion": "API para entidade Tabela de Preço para produtos TOTVS Varejo",
-				"segment": "Varejo"
-			},
-			"productInformation": [
-				{
-					"product": "Protheus",
-					"contact": "rafael.pessoa@totvs.com.br",
-					"description": "Cadastro de Tabela de Preços Varejo",
-					"adapter": "RetailPriceList.PRW      -",
-					"helpUrl": ""
-				}
-			]
-		}
-	},
-	"paths": {
-		"/retailPriceList": {
-			"get": {
-				"tags": [
-					"priceListHeaderItem"
-				],
-				"summary": "Retorna lista de Tabelas de Preço",
-				"x-totvs": {
-					"productInformation": [
-						{
-							"product": "Protheus",
-							"available": true,
-							"minimalVersion": "12.1.23"
-						}
-					]
-				},
-				"description": "Retorna lista de Tabela de Preço",
-				"operationId": "getpriceListHeaderItem",
-				"parameters": [
-					{
-						"$ref": "https://raw.githubusercontent.com/totvs/ttalk-standard-message/master/jsonschema/apis/types/totvsApiTypesBase.json#/parameters/Authorization"
-					},
-					{
-						"$ref": "https://raw.githubusercontent.com/totvs/ttalk-standard-message/master/jsonschema/apis/types/totvsApiTypesBase.json#/parameters/Order"
-					},
-					{
-						"$ref": "https://raw.githubusercontent.com/totvs/ttalk-standard-message/master/jsonschema/apis/types/totvsApiTypesBase.json#/parameters/Fields"
-					},
-					{
-						"$ref": "https://raw.githubusercontent.com/totvs/ttalk-standard-message/master/jsonschema/apis/types/totvsApiTypesBase.json#/parameters/Page"
-					},
-					{
-						"$ref": "https://raw.githubusercontent.com/totvs/ttalk-standard-message/master/jsonschema/apis/types/totvsApiTypesBase.json#/parameters/PageSize"
-					}
-				],
-				"responses": {
-					"200": {
-						"description": "Operação realizada com sucesso!",
-						"content": {
-							"application/json": {
-								"schema": {
-									"$ref": "https://raw.githubusercontent.com/totvs/ttalk-standard-message/RetailPriceList/v1/2_006/jsonschema/schemas/PriceListHeaderItem_2_006.json#/definitions/PagedPriceListHeader"
-								}
-							}
-						}
-					},
-					"404": {
-						"description": "Registro não encontrado!",
-						"content": {
-							"application/json": {
-								"schema": {
-									"$ref": "https://raw.githubusercontent.com/totvs/ttalk-standard-message/master/jsonschema/apis/types/totvsApiTypesBase.json#/definitions/ErrorModel"
-								}
-							}
-						}
-					}
-				},
-				"security": [
-					{
-						"api_key": []
-					}
-				]
-			},
-			"post": {
-				"tags": [
-					"priceListHeaderItem"
-				],
-				"summary": "Inclui uma Tabela de Preço",
-				"x-totvs": {
-					"productInformation": [
-						{
-							"product": "Protheus",
-							"available": false,
-							"minimalVersion": "12.1.23"
-						}
-					]
-				},
-				"description": "Inclui uma tabela de preço conforme dados enviados na requisição.",
-				"operationId": "postpriceListHeaderItem",
-				"parameters": [
-					{
-						"$ref": "https://raw.githubusercontent.com/totvs/ttalk-standard-message/master/jsonschema/apis/types/totvsApiTypesBase.json#/parameters/Authorization"
-					}
-				],
-				"requestBody": {
-					"description": "Tabela de preço a ser incluída.",
-					"content": {
-						"application/json": {
-							"schema": {
-								"$ref": "https://raw.githubusercontent.com/totvs/ttalk-standard-message/RetailPriceList/v1/2_006/jsonschema/schemas/PriceListHeaderItem_2_006.json#/definitions/PagedPriceListHeaderItems"
-							}
-						}
-					}
-				},
-				"responses": {
-					"201": {
-						"description": "Operação realizada com sucesso!",
-						"content": {
-							"application/json": {
-								"schema": {
-									"$ref": "https://raw.githubusercontent.com/totvs/ttalk-standard-message/RetailPriceList/v1/2_006/jsonschema/schemas/PriceListHeaderItem_2_006.json#/definitions/PagedPriceListHeaderItems"
-								}
-							}
-						}
-					},
-					"400": {
-						"description": "Erro durante inclusão da tabela de preço!",
-						"content": {
-							"application/json": {
-								"schema": {
-									"$ref": "https://raw.githubusercontent.com/totvs/ttalk-standard-message/master/jsonschema/apis/types/totvsApiTypesBase.json#/definitions/ErrorModel"
-								}
-							}
-						}
-					}
-				},
-				"security": [
-					{
-						"api_key": []
-					}
-				]
-			}
-		},
-		"/retailPriceList/{InternalId}": {
-			"get": {
-				"tags": [
-					"InternalId"
-				],
-				"summary": "Buscar Tabela de Preço por InternalId que é Identificador único da Tabela de Preço",
-				"operationId": "getpriceListInternalId",
-				"x-totvs": {
-					"produtcInformation": [
-						{
-							"product": "Protheus",
-							"available": true,
-							"note": "Este verbo está disponível com os parâmetros Authorization e InternalId.",
-							"minimalVersion": "12.1.23"
-						}
-					]
-				},
-				"parameters": [
-					{
-						"$ref": "https://raw.githubusercontent.com/totvs/ttalk-standard-message/master/jsonschema/apis/types/totvsApiTypesBase.json#/parameters/Authorization"
-					},
-					{
-						"$ref": "#/components/parameters/code"
-					},
-					{
-						"$ref": "https://raw.githubusercontent.com/totvs/ttalk-standard-message/master/jsonschema/apis/types/totvsApiTypesBase.json#/parameters/Order"
-					},
-					{
-						"$ref": "https://raw.githubusercontent.com/totvs/ttalk-standard-message/master/jsonschema/apis/types/totvsApiTypesBase.json#/parameters/Fields"
-					},
-					{
-						"$ref": "#/components/parameters/InternalId"
-					}
-				],
-				"responses": {
-					"200": {
-						"description": "Operação realizada com sucesso!",
-						"content": {
-							"application/json": {
-								"schema": {
-									"$ref": "https://raw.githubusercontent.com/totvs/ttalk-standard-message/RetailPriceList/v1/2_006/jsonschema/schemas/PriceListHeaderItem_2_006.json#/definitions/PagedPriceListHeaderItems"
-								}
-							}
-						}
-					},
-					"404": {
-						"description": "Registro não encontrado!",
-						"content": {
-							"application/json": {
-								"schema": {
-									"$ref": "https://raw.githubusercontent.com/totvs/ttalk-standard-message/master/jsonschema/apis/types/totvsApiTypesBase.json#/definitions/ErrorModel"
-								}
-							}
-						}
-					}
-				},
-				"security": [
-					{
-						"api_key": []
-					}
-				]
-			}
-		},
-		"/retailPriceList/{code}": {
-			"get": {
-				"tags": [
-					"code"
-				],
-				"summary": "Retorna a tabela de preço e todos os seus itens de acordo com o seu código",
-				"operationId": "getpriceListCode",
-				"x-totvs": {
-					"produtcInformation": [
-						{
-							"product": "Protheus",
-							"available": false,
-							"note": "Este verbo está disponível com os parâmetros Authorization e code.",
-							"minimalVersion": "12.1.23"
-						}
-					]
-				},
-				"parameters": [
-					{
-						"$ref": "https://raw.githubusercontent.com/totvs/ttalk-standard-message/master/jsonschema/apis/types/totvsApiTypesBase.json#/parameters/Authorization"
-					},
-					{
-						"$ref": "#/components/parameters/code"
-					},
-					{
-						"$ref": "https://raw.githubusercontent.com/totvs/ttalk-standard-message/master/jsonschema/apis/types/totvsApiTypesBase.json#/parameters/Order"
-					},
-					{
-						"$ref": "https://raw.githubusercontent.com/totvs/ttalk-standard-message/master/jsonschema/apis/types/totvsApiTypesBase.json#/parameters/Fields"
-					}
-				],
-				"responses": {
-					"200": {
-						"description": "Operação realizada com sucesso!",
-						"content": {
-							"application/json": {
-								"schema": {
-									"$ref": "https://raw.githubusercontent.com/totvs/ttalk-standard-message/RetailPriceList/v1/2_006/jsonschema/schemas/PriceListHeaderItem_2_006.json#/definitions/PagedPriceListHeaderItems"
-								}
-							}
-						}
-					},
-					"404": {
-						"description": "Registro não encontrado!",
-						"content": {
-							"application/json": {
-								"schema": {
-									"$ref": "https://raw.githubusercontent.com/totvs/ttalk-standard-message/master/jsonschema/apis/types/totvsApiTypesBase.json#/definitions/ErrorModel"
-								}
-							}
-						}
-					}
-				},
-				"security": [
-					{
-						"api_key": []
-					}
-				]
-			},
-			"put": {
-				"tags": [
-					"code"
-				],
-				"summary": "Altera o Cabeçalho da tabela de preço",
-				"description": "Atualiza o cadastro da tabela de preço conforme dados enviados na requisição",
-				"operationId": "putpriceListCode",
-				"x-totvs": {
-					"produtcInformation": [
-						{
-							"product": "Protheus",
-							"available": false,
-							"note": "Este verbo está disponível com os parâmetros Authorization e code.",
-							"minimalVersion": "12.1.23"
-						}
-					]
-				},
-				"parameters": [
-					{
-						"$ref": "https://raw.githubusercontent.com/totvs/ttalk-standard-message/master/jsonschema/apis/types/totvsApiTypesBase.json#/parameters/Authorization"
-					},
-					{
-						"$ref": "#/components/parameters/code"
-					}
-				],
-				"requestBody": {
-					"description": "Tabela de preço a ser atualizada.",
-					"content": {
-						"application/json": {
-							"schema": {
-								"$ref": "https://raw.githubusercontent.com/totvs/ttalk-standard-message/RetailPriceList/v1/2_006/jsonschema/schemas/PriceListHeaderItem_2_006.json#/definitions/PagedPriceListHeaderItems"
-							}
-						}
-					}
-				},
-				"responses": {
-					"200": {
-						"description": "Operação realizada com sucesso!",
-						"content": {
-							"application/json": {
-								"schema": {
-									"$ref": "https://raw.githubusercontent.com/totvs/ttalk-standard-message/RetailPriceList/v1/2_006/jsonschema/schemas/PriceListHeaderItem_2_006.json#/definitions/PagedPriceListHeaderItems"
-								}
-							}
-						}
-					},
-					"400": {
-						"description": "Erro durante a alteração da tabela de preço!",
-						"content": {
-							"application/json": {
-								"schema": {
-									"$ref": "https://raw.githubusercontent.com/totvs/ttalk-standard-message/master/jsonschema/apis/types/totvsApiTypesBase.json#/definitions/ErrorModel"
-								}
-							}
-						}
-					},
-					"404": {
-						"description": "Registro não encontrado!",
-						"content": {
-							"application/json": {
-								"schema": {
-									"$ref": "https://raw.githubusercontent.com/totvs/ttalk-standard-message/master/jsonschema/apis/types/totvsApiTypesBase.json#/definitions/ErrorModel"
-								}
-							}
-						}
-					}
-				},
-				"security": [
-					{
-						"api_key": []
-					}
-				]
-			},
-			"delete": {
-				"tags": [
-					"code"
-				],
-				"summary": "Exclui uma tabela de preço",
-				"description": "Exclui a tabela de preço conforme dados enviados na requisição.",
-				"operationId": "deletepriceListCode",
-				"x-totvs": {
-					"produtcInformation": [
-						{
-							"product": "Protheus",
-							"available": false,
-							"note": "Este verbo está disponível com os parâmetros Authorization e code.",
-							"minimalVersion": "12.1.23"
-						}
-					]
-				},
-				"parameters": [
-					{
-						"$ref": "https://raw.githubusercontent.com/totvs/ttalk-standard-message/master/jsonschema/apis/types/totvsApiTypesBase.json#/parameters/Authorization"
-					},
-					{
-						"$ref": "#/components/parameters/code"
-					}
-				],
-				"responses": {
-					"200": {
-						"description": "Operação realizada com sucesso!",
-						"content": {
-							"application/json": {
-								"schema": {
-									"$ref": "https://raw.githubusercontent.com/totvs/ttalk-standard-message/RetailPriceList/v1/2_006/jsonschema/schemas/PriceListHeaderItem_2_006.json#/definitions/PagedPriceListHeaderItems"
-								}
-							}
-						}
-					},
-					"400": {
-						"description": "Erro durante a exclusão da tabela de preço!",
-						"content": {
-							"application/json": {
-								"schema": {
-									"$ref": "https://raw.githubusercontent.com/totvs/ttalk-standard-message/master/jsonschema/apis/types/totvsApiTypesBase.json#/definitions/ErrorModel"
-								}
-							}
-						}
-					},
-					"404": {
-						"description": "Registro não encontrado!",
-						"content": {
-							"application/json": {
-								"schema": {
-									"$ref": "https://raw.githubusercontent.com/totvs/ttalk-standard-message/master/jsonschema/apis/types/totvsApiTypesBase.json#/definitions/ErrorModel"
-								}
-							}
-						}
-					}
-				},
-				"security": [
-					{
-						"api_key": []
-					}
-				]
-			}
-		},
-		"/retailPriceList/{InternalId}/itensTablePrice/": {
-			"get": {
-				"tags": [
-					"itensTablePriceInternalId"
-				],
-				"summary": "Retorna os itens da tabela de preço de acordo com o InternalId",
-				"operationId": "getpriceListItemsInternalId",
-				"x-totvs": {
-					"productInformation": [
-						{
-							"product": "Protheus",
-							"available": true,
-							"note": "Este verbo está disponível com os parâmetros Authorization e InternalId.",
-							"minimalVersion": "12.1.23"
-						}
-					]
-				},
-				"parameters": [
-					{
-						"$ref": "https://raw.githubusercontent.com/totvs/ttalk-standard-message/master/jsonschema/apis/types/totvsApiTypesBase.json#/parameters/Authorization"
-					},
-					{
-						"$ref": "#/components/parameters/code"
-					},
-					{
-						"$ref": "https://raw.githubusercontent.com/totvs/ttalk-standard-message/master/jsonschema/apis/types/totvsApiTypesBase.json#/parameters/Order"
-					},
-					{
-						"$ref": "https://raw.githubusercontent.com/totvs/ttalk-standard-message/master/jsonschema/apis/types/totvsApiTypesBase.json#/parameters/Fields"
-					},
-					{
-						"$ref": "https://raw.githubusercontent.com/totvs/ttalk-standard-message/master/jsonschema/apis/types/totvsApiTypesBase.json#/parameters/Page"
-					},
-					{
-						"$ref": "https://raw.githubusercontent.com/totvs/ttalk-standard-message/master/jsonschema/apis/types/totvsApiTypesBase.json#/parameters/PageSize"
-					},
-					{
-						"$ref": "#/components/parameters/InternalId"
-					}
-				],
-				"responses": {
-					"200": {
-						"description": "Operação realizada com sucesso!",
-						"content": {
-							"application/json": {
-								"schema": {
-									"$ref": "https://raw.githubusercontent.com/totvs/ttalk-standard-message/RetailPriceList/v1/2_006/jsonschema/schemas/PriceListHeaderItem_2_006.json#/definitions/PagedItensTablePrice"
-								}
-							}
-						}
-					},
-					"404": {
-						"description": "Registro não encontrado!",
-						"content": {
-							"application/json": {
-								"schema": {
-									"$ref": "https://raw.githubusercontent.com/totvs/ttalk-standard-message/master/jsonschema/apis/types/totvsApiTypesBase.json#/definitions/ErrorModel"
-								}
-							}
-						}
-					}
-				},
-				"security": [
-					{
-						"api_key": []
-					}
-				]
-			}
-		},
-		"/retailPriceList/{code}/itensTablePrice/": {
-			"get": {
-				"tags": [
-					"itensTablePrice"
-				],
-				"summary": "Retorna os itens da tabela de preço de acordo com o seu código",
-				"operationId": "getpriceListItems",
-				"x-totvs": {
-					"productInformation": [
-						{
-							"product": "Protheus",
-							"available": false,
-							"note": "Este verbo está disponível com os parâmetros Authorization e code.",
-							"minimalVersion": "12.1.23"
-						}
-					]
-				},
-				"parameters": [
-					{
-						"$ref": "https://raw.githubusercontent.com/totvs/ttalk-standard-message/master/jsonschema/apis/types/totvsApiTypesBase.json#/parameters/Authorization"
-					},
-					{
-						"$ref": "#/components/parameters/code"
-					},
-					{
-						"$ref": "https://raw.githubusercontent.com/totvs/ttalk-standard-message/master/jsonschema/apis/types/totvsApiTypesBase.json#/parameters/Order"
-					},
-					{
-						"$ref": "https://raw.githubusercontent.com/totvs/ttalk-standard-message/master/jsonschema/apis/types/totvsApiTypesBase.json#/parameters/Fields"
-					},
-					{
-						"$ref": "https://raw.githubusercontent.com/totvs/ttalk-standard-message/master/jsonschema/apis/types/totvsApiTypesBase.json#/parameters/Page"
-					},
-					{
-						"$ref": "https://raw.githubusercontent.com/totvs/ttalk-standard-message/master/jsonschema/apis/types/totvsApiTypesBase.json#/parameters/PageSize"
-					}
-				],
-				"responses": {
-					"200": {
-						"description": "Operação realizada com sucesso!",
-						"content": {
-							"application/json": {
-								"schema": {
-									"$ref": "https://raw.githubusercontent.com/totvs/ttalk-standard-message/RetailPriceList/v1/2_006/jsonschema/schemas/PriceListHeaderItem_2_006.json#/definitions/PagedItensTablePrice"
-								}
-							}
-						}
-					},
-					"404": {
-						"description": "Registro não encontrado!",
-						"content": {
-							"application/json": {
-								"schema": {
-									"$ref": "https://raw.githubusercontent.com/totvs/ttalk-standard-message/master/jsonschema/apis/types/totvsApiTypesBase.json#/definitions/ErrorModel"
-								}
-							}
-						}
-					}
-				},
-				"security": [
-					{
-						"api_key": []
-					}
-				]
-			},
-			"post": {
-				"tags": [
-					"itensTablePrice"
-				],
-				"summary": "Inclui um item na Tabela de Preço",
-				"description": "Inclui um novo item na tabela de preço conforme dados enviados.",
-				"operationId": "postpriceListItems",
-				"x-totvs": {
-					"productInformation": [
-						{
-							"product": "Protheus",
-							"available": false,
-							"note": "Este verbo está disponível com os parâmetros Authorization e code.",
-							"minimalVersion": "12.1.23"
-						}
-					]
-				},
-				"parameters": [
-					{
-						"$ref": "https://raw.githubusercontent.com/totvs/ttalk-standard-message/master/jsonschema/apis/types/totvsApiTypesBase.json#/parameters/Authorization"
-					},
-					{
-						"$ref": "#/components/parameters/code"
-					}
-				],
-				"requestBody": {
-					"description": "Tabela de preço a ser incluída.",
-					"content": {
-						"application/json": {
-							"schema": {
-								"$ref": "https://raw.githubusercontent.com/totvs/ttalk-standard-message/RetailPriceList/v1/2_006/jsonschema/schemas/PriceListHeaderItem_2_006.json#/definitions/itensTablePrices"
-							}
-						}
-					}
-				},
-				"responses": {
-					"201": {
-						"description": "Operação realizada com sucesso!",
-						"content": {
-							"application/json": {
-								"schema": {
-									"$ref": "https://raw.githubusercontent.com/totvs/ttalk-standard-message/RetailPriceList/v1/2_006/jsonschema/schemas/PriceListHeaderItem_2_006.json#/definitions/PagedItensTablePrice"
-								}
-							}
-						}
-					},
-					"400": {
-						"description": "Erro durante inclusão da tabela de preço!",
-						"content": {
-							"application/json": {
-								"schema": {
-									"$ref": "https://raw.githubusercontent.com/totvs/ttalk-standard-message/master/jsonschema/apis/types/totvsApiTypesBase.json#/definitions/ErrorModel"
-								}
-							}
-						}
-					}
-				},
-				"security": [
-					{
-						"api_key": []
-					}
-				]
-			}
-		},
-		"/retailPriceList/{InternalId}/itensTablePrice/{itemList}": {
-			"get": {
-				"tags": [
-					"itemTablePriceInternalId"
-				],
-				"summary": "Retorna um item específico de preço de acordo com o seu código",
-				"operationId": "getpriceListItemListInternalId",
-				"x-totvs": {
-					"productInformation": [
-						{
-							"product": "Protheus",
-							"available": false,
-							"note": "Este verbo está disponível com os parâmetros Authorization e code.",
-							"minimalVersion": "12.1.23"
-						}
-					]
-				},
-				"parameters": [
-					{
-						"$ref": "https://raw.githubusercontent.com/totvs/ttalk-standard-message/master/jsonschema/apis/types/totvsApiTypesBase.json#/parameters/Authorization"
-					},
-					{
-						"$ref": "#/components/parameters/code"
-					},
-					{
-						"$ref": "#/components/parameters/itemList"
-					},
-					{
-						"$ref": "https://raw.githubusercontent.com/totvs/ttalk-standard-message/master/jsonschema/apis/types/totvsApiTypesBase.json#/parameters/Order"
-					},
-					{
-						"$ref": "https://raw.githubusercontent.com/totvs/ttalk-standard-message/master/jsonschema/apis/types/totvsApiTypesBase.json#/parameters/Fields"
-					},
-					{
-						"$ref": "https://raw.githubusercontent.com/totvs/ttalk-standard-message/master/jsonschema/apis/types/totvsApiTypesBase.json#/parameters/Page"
-					},
-					{
-						"$ref": "https://raw.githubusercontent.com/totvs/ttalk-standard-message/master/jsonschema/apis/types/totvsApiTypesBase.json#/parameters/PageSize"
-					},
-					{
-						"$ref": "#/components/parameters/InternalId"
-					}
-				],
-				"responses": {
-					"200": {
-						"description": "Operação realizada com sucesso!",
-						"content": {
-							"application/json": {
-								"schema": {
-									"$ref": "https://raw.githubusercontent.com/totvs/ttalk-standard-message/RetailPriceList/v1/2_006/jsonschema/schemas/PriceListHeaderItem_2_006.json#/definitions/PagedItensTablePrice"
-								}
-							}
-						}
-					},
-					"404": {
-						"description": "Registro não encontrado!",
-						"content": {
-							"application/json": {
-								"schema": {
-									"$ref": "https://raw.githubusercontent.com/totvs/ttalk-standard-message/master/jsonschema/apis/types/totvsApiTypesBase.json#/definitions/ErrorModel"
-								}
-							}
-						}
-					}
-				},
-				"security": [
-					{
-						"api_key": []
-					}
-				]
-			}
-		},
-		"/retailPriceList/{code}/itensTablePrice/{itemList}": {
-			"get": {
-				"tags": [
-					"itemTablePrice"
-				],
-				"summary": "Retorna um item específico de preço de acordo com o seu código",
-				"operationId": "getpriceListItemList",
-				"x-totvs": {
-					"productInformation": [
-						{
-							"product": "Protheus",
-							"available": false,
-							"note": "Este verbo está disponível com os parâmetros Authorization e code.",
-							"minimalVersion": "12.1.23"
-						}
-					]
-				},
-				"parameters": [
-					{
-						"$ref": "https://raw.githubusercontent.com/totvs/ttalk-standard-message/master/jsonschema/apis/types/totvsApiTypesBase.json#/parameters/Authorization"
-					},
-					{
-						"$ref": "#/components/parameters/code"
-					},
-					{
-						"$ref": "#/components/parameters/itemList"
-					},
-					{
-						"$ref": "https://raw.githubusercontent.com/totvs/ttalk-standard-message/master/jsonschema/apis/types/totvsApiTypesBase.json#/parameters/Order"
-					},
-					{
-						"$ref": "https://raw.githubusercontent.com/totvs/ttalk-standard-message/master/jsonschema/apis/types/totvsApiTypesBase.json#/parameters/Fields"
-					},
-					{
-						"$ref": "https://raw.githubusercontent.com/totvs/ttalk-standard-message/master/jsonschema/apis/types/totvsApiTypesBase.json#/parameters/Page"
-					},
-					{
-						"$ref": "https://raw.githubusercontent.com/totvs/ttalk-standard-message/master/jsonschema/apis/types/totvsApiTypesBase.json#/parameters/PageSize"
-					}
-				],
-				"responses": {
-					"200": {
-						"description": "Operação realizada com sucesso!",
-						"content": {
-							"application/json": {
-								"schema": {
-									"$ref": "https://raw.githubusercontent.com/totvs/ttalk-standard-message/RetailPriceList/v1/2_006/jsonschema/schemas/PriceListHeaderItem_2_006.json#/definitions/PagedItensTablePrice"
-								}
-							}
-						}
-					},
-					"404": {
-						"description": "Registro não encontrado!",
-						"content": {
-							"application/json": {
-								"schema": {
-									"$ref": "https://raw.githubusercontent.com/totvs/ttalk-standard-message/master/jsonschema/apis/types/totvsApiTypesBase.json#/definitions/ErrorModel"
-								}
-							}
-						}
-					}
-				},
-				"security": [
-					{
-						"api_key": []
-					}
-				]
-			},
-			"put": {
-				"tags": [
-					"itemTablePrice"
-				],
-				"summary": "Altera um item da tabela de preço",
-				"description": "Atualiza um item da tabela de preço conforme dados enviados na requisição",
-				"operationId": "putpriceListItemList",
-				"x-totvs": {
-					"productInformation": [
-						{
-							"product": "Protheus",
-							"available": false,
-							"note": "Este verbo está disponível com os parâmetros Authorization e code.",
-							"minimalVersion": "12.1.23"
-						}
-					]
-				},
-				"parameters": [
-					{
-						"$ref": "https://raw.githubusercontent.com/totvs/ttalk-standard-message/master/jsonschema/apis/types/totvsApiTypesBase.json#/parameters/Authorization"
-					},
-					{
-						"$ref": "#/components/parameters/code"
-					},
-					{
-						"$ref": "#/components/parameters/itemList"
-					},
-					{
-						"$ref": "https://raw.githubusercontent.com/totvs/ttalk-standard-message/master/jsonschema/apis/types/totvsApiTypesBase.json#/parameters/Fields"
-					}
-				],
-				"requestBody": {
-					"description": "Tabela de preço a ser atualizada.",
-					"content": {
-						"application/json": {
-							"schema": {
-								"$ref": "https://raw.githubusercontent.com/totvs/ttalk-standard-message/RetailPriceList/v1/2_006/jsonschema/schemas/PriceListHeaderItem_2_006.json#/definitions/itensTablePrices"
-							}
-						}
-					}
-				},
-				"responses": {
-					"200": {
-						"description": "Operação realizada com sucesso!",
-						"content": {
-							"application/json": {
-								"schema": {
-									"$ref": "https://raw.githubusercontent.com/totvs/ttalk-standard-message/RetailPriceList/v1/2_006/jsonschema/schemas/PriceListHeaderItem_2_006.json#/definitions/PagedItensTablePrice"
-								}
-							}
-						}
-					},
-					"400": {
-						"description": "Erro ao alterar a tabela de preço!",
-						"content": {
-							"application/json": {
-								"schema": {
-									"$ref": "https://raw.githubusercontent.com/totvs/ttalk-standard-message/master/jsonschema/apis/types/totvsApiTypesBase.json#/definitions/ErrorModel"
-								}
-							}
-						}
-					},
-					"404": {
-						"description": "Registro não encontrado!",
-						"content": {
-							"application/json": {
-								"schema": {
-									"$ref": "https://raw.githubusercontent.com/totvs/ttalk-standard-message/master/jsonschema/apis/types/totvsApiTypesBase.json#/definitions/ErrorModel"
-								}
-							}
-						}
-					}
-				},
-				"security": [
-					{
-						"api_key": []
-					}
-				]
-			},
-			"delete": {
-				"tags": [
-					"itemTablePrice"
-				],
-				"summary": "Exclui um item da tabela de preço",
-				"description": "Exclui um item da tabela de preço conforme dados enviados na requisição.",
-				"operationId": "deletepriceListItemList",
-				"x-totvs": {
-					"productInformation": [
-						{
-							"product": "Protheus",
-							"available": false,
-							"note": "Este verbo está disponível com os parâmetros Authorization e code.",
-							"minimalVersion": "12.1.23"
-						}
-					]
-				},
-				"parameters": [
-					{
-						"$ref": "https://raw.githubusercontent.com/totvs/ttalk-standard-message/master/jsonschema/apis/types/totvsApiTypesBase.json#/parameters/Authorization"
-					},
-					{
-						"$ref": "#/components/parameters/code"
-					},
-					{
-						"$ref": "#/components/parameters/itemList"
-					}
-				],
-				"responses": {
-					"200": {
-						"description": "Operação realizada com sucesso!",
-						"content": {
-							"application/json": {
-								"schema": {
-									"$ref": "https://raw.githubusercontent.com/totvs/ttalk-standard-message/RetailPriceList/v1/2_006/jsonschema/schemas/PriceListHeaderItem_2_006.json#/definitions/PagedPriceListHeaderItems"
-								}
-							}
-						}
-					},
-					"400": {
-						"description": "Erro durante a exclusão da tabela de preço! ",
-						"content": {
-							"application/json": {
-								"schema": {
-									"$ref": "https://raw.githubusercontent.com/totvs/ttalk-standard-message/master/jsonschema/apis/types/totvsApiTypesBase.json#/definitions/ErrorModel"
-								}
-							}
-						}
-					},
-					"404": {
-						"description": "Registro não encontrado!",
-						"content": {
-							"application/json": {
-								"schema": {
-									"$ref": "https://raw.githubusercontent.com/totvs/ttalk-standard-message/master/jsonschema/apis/types/totvsApiTypesBase.json#/definitions/ErrorModel"
-								}
-							}
-						}
-					}
-				},
-				"security": [
-					{
-						"api_key": []
-					}
-				]
-			}
-		}
-	},
-	"components": {
-		"parameters": {
-			"code": {
-				"name": "code",
-				"in": "path",
-				"required": true,
-				"description": "Identificador único da tabela de preço",
-				"schema": {
-					"type": "string"
-				}
-			},
-			"InternalId": {
-				"name": "InternalId",
-				"in": "path",
-				"required": true,
-				"description": "Identificador único da tabela de preço",
-				"schema": {
-					"type": "string"
-				}
-			},
-			"itemList": {
-				"name": "itemList",
-				"in": "path",
-				"required": true,
-				"description": "Identificador do item da tabela de preço",
-				"schema": {
-					"$ref": "https://raw.githubusercontent.com/totvs/ttalk-standard-message/RetailPriceList/v1/2_006/jsonschema/schemas/PriceListHeaderItem_2_006.json#/definitions/itensTablePriceInfo"
-				}
-			}
-		},
-		"schemas": {}
-	}
+  "openapi": "3.0.1",
+  "servers": [
+    {
+      "description": "API para cadastro tabela de preços dos produtos TOTVS Varejo",
+      "url": "http://{serverUrl}:{serverHttpPort}/api/retail/v1",
+      "variables": {
+        "serverUrl": {
+          "default": "localhost"
+        },
+        "serverHttpPort": {
+          "default": "8051"
+        }
+      }
+    }
+  ],
+  "info": {
+    "description": "API para manutenção de tabela de preço para os produtos TOTVS Varejo",
+    "version": "1.000",
+    "title": "Tabela de Preços Varejo",
+    "contact": {
+      "name": "T-Talk",
+      "url": "api.totvs.com.br",
+      "email": "comiteintegracao@totvs.com.br"
+    },
+    "x-totvs": {
+      "messageDocumentation": {
+        "name": "RetailPriceList",
+        "descriotion": "API para entidade Tabela de Preço para produtos TOTVS Varejo",
+        "segment": "Varejo"
+      },
+      "productInformation": [
+        {
+          "product": "Protheus",
+          "contact": "rafael.pessoa@totvs.com.br",
+          "description": "Cadastro de Tabela de Preços Varejo",
+          "adapter": "RetailPriceList.PRW      -",
+          "helpUrl": ""
+        }
+      ]
+    }
+  },
+  "paths": {
+    "/retailPriceList": {
+      "get": {
+        "tags": [
+          "priceListHeaderItem"
+        ],
+        "summary": "Retorna lista de Tabelas de Preço",
+        "x-totvs": {
+          "productInformation": [
+            {
+              "product": "Protheus",
+              "available": true,
+              "minimalVersion": "12.1.23"
+            }
+          ]
+        },
+        "description": "Retorna lista de Tabela de Preço",
+        "operationId": "getpriceListHeaderItem",
+        "parameters": [
+          {
+            "$ref": "https://raw.githubusercontent.com/totvs/ttalk-standard-message/master/jsonschema/apis/types/totvsApiTypesBase.json#/parameters/Authorization"
+          },
+          {
+            "$ref": "https://raw.githubusercontent.com/totvs/ttalk-standard-message/master/jsonschema/apis/types/totvsApiTypesBase.json#/parameters/Order"
+          },
+          {
+            "$ref": "https://raw.githubusercontent.com/totvs/ttalk-standard-message/master/jsonschema/apis/types/totvsApiTypesBase.json#/parameters/Fields"
+          },
+          {
+            "$ref": "https://raw.githubusercontent.com/totvs/ttalk-standard-message/master/jsonschema/apis/types/totvsApiTypesBase.json#/parameters/Page"
+          },
+          {
+            "$ref": "https://raw.githubusercontent.com/totvs/ttalk-standard-message/master/jsonschema/apis/types/totvsApiTypesBase.json#/parameters/PageSize"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Operação realizada com sucesso!",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "https://raw.githubusercontent.com/totvs/ttalk-standard-message/RetailPriceList/v1/2_006/jsonschema/schemas/PriceListHeaderItem_2_006.json#/definitions/PagedPriceListHeader"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Registro não encontrado!",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "https://raw.githubusercontent.com/totvs/ttalk-standard-message/master/jsonschema/apis/types/totvsApiTypesBase.json#/definitions/ErrorModel"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "api_key": []
+          }
+        ]
+      },
+      "post": {
+        "tags": [
+          "priceListHeaderItem"
+        ],
+        "summary": "Inclui uma Tabela de Preço",
+        "x-totvs": {
+          "productInformation": [
+            {
+              "product": "Protheus",
+              "available": false,
+              "minimalVersion": "12.1.23"
+            }
+          ]
+        },
+        "description": "Inclui uma tabela de preço conforme dados enviados na requisição.",
+        "operationId": "postpriceListHeaderItem",
+        "parameters": [
+          {
+            "$ref": "https://raw.githubusercontent.com/totvs/ttalk-standard-message/master/jsonschema/apis/types/totvsApiTypesBase.json#/parameters/Authorization"
+          }
+        ],
+        "requestBody": {
+          "description": "Tabela de preço a ser incluída.",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "https://raw.githubusercontent.com/totvs/ttalk-standard-message/RetailPriceList/v1/2_006/jsonschema/schemas/PriceListHeaderItem_2_006.json#/definitions/PagedPriceListHeaderItems"
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "Operação realizada com sucesso!",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "https://raw.githubusercontent.com/totvs/ttalk-standard-message/RetailPriceList/v1/2_006/jsonschema/schemas/PriceListHeaderItem_2_006.json#/definitions/PagedPriceListHeaderItems"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Erro durante inclusão da tabela de preço!",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "https://raw.githubusercontent.com/totvs/ttalk-standard-message/master/jsonschema/apis/types/totvsApiTypesBase.json#/definitions/ErrorModel"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "api_key": []
+          }
+        ]
+      }
+    },
+    "/retailPriceList/{InternalId}": {
+      "get": {
+        "tags": [
+          "InternalId"
+        ],
+        "summary": "Buscar Tabela de Preço por InternalId que é Identificador único da Tabela de Preço",
+        "operationId": "getpriceListInternalId",
+        "x-totvs": {
+          "produtcInformation": [
+            {
+              "product": "Protheus",
+              "available": true,
+              "note": "Este verbo está disponível com os parâmetros Authorization e InternalId.",
+              "minimalVersion": "12.1.23"
+            }
+          ]
+        },
+        "parameters": [
+          {
+            "$ref": "https://raw.githubusercontent.com/totvs/ttalk-standard-message/master/jsonschema/apis/types/totvsApiTypesBase.json#/parameters/Authorization"
+          },
+          {
+            "$ref": "#/components/parameters/code"
+          },
+          {
+            "$ref": "https://raw.githubusercontent.com/totvs/ttalk-standard-message/master/jsonschema/apis/types/totvsApiTypesBase.json#/parameters/Order"
+          },
+          {
+            "$ref": "https://raw.githubusercontent.com/totvs/ttalk-standard-message/master/jsonschema/apis/types/totvsApiTypesBase.json#/parameters/Fields"
+          },
+          {
+            "$ref": "#/components/parameters/InternalId"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Operação realizada com sucesso!",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "https://raw.githubusercontent.com/totvs/ttalk-standard-message/RetailPriceList/v1/2_006/jsonschema/schemas/PriceListHeaderItem_2_006.json#/definitions/PriceListHeaderItemsInfo"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Registro não encontrado!",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "https://raw.githubusercontent.com/totvs/ttalk-standard-message/master/jsonschema/apis/types/totvsApiTypesBase.json#/definitions/ErrorModel"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "api_key": []
+          }
+        ]
+      }
+    },
+    "/retailPriceList/{code}": {
+      "get": {
+        "tags": [
+          "code"
+        ],
+        "summary": "Retorna a tabela de preço e todos os seus itens de acordo com o seu código",
+        "operationId": "getpriceListCode",
+        "x-totvs": {
+          "produtcInformation": [
+            {
+              "product": "Protheus",
+              "available": false,
+              "note": "Este verbo está disponível com os parâmetros Authorization e code.",
+              "minimalVersion": "12.1.23"
+            }
+          ]
+        },
+        "parameters": [
+          {
+            "$ref": "https://raw.githubusercontent.com/totvs/ttalk-standard-message/master/jsonschema/apis/types/totvsApiTypesBase.json#/parameters/Authorization"
+          },
+          {
+            "$ref": "#/components/parameters/code"
+          },
+          {
+            "$ref": "https://raw.githubusercontent.com/totvs/ttalk-standard-message/master/jsonschema/apis/types/totvsApiTypesBase.json#/parameters/Order"
+          },
+          {
+            "$ref": "https://raw.githubusercontent.com/totvs/ttalk-standard-message/master/jsonschema/apis/types/totvsApiTypesBase.json#/parameters/Fields"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Operação realizada com sucesso!",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "https://raw.githubusercontent.com/totvs/ttalk-standard-message/RetailPriceList/v1/2_006/jsonschema/schemas/PriceListHeaderItem_2_006.json#/definitions/PriceListHeaderItemsInfo"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Registro não encontrado!",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "https://raw.githubusercontent.com/totvs/ttalk-standard-message/master/jsonschema/apis/types/totvsApiTypesBase.json#/definitions/ErrorModel"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "api_key": []
+          }
+        ]
+      },
+      "put": {
+        "tags": [
+          "code"
+        ],
+        "summary": "Altera o Cabeçalho da tabela de preço",
+        "description": "Atualiza o cadastro da tabela de preço conforme dados enviados na requisição",
+        "operationId": "putpriceListCode",
+        "x-totvs": {
+          "produtcInformation": [
+            {
+              "product": "Protheus",
+              "available": false,
+              "note": "Este verbo está disponível com os parâmetros Authorization e code.",
+              "minimalVersion": "12.1.23"
+            }
+          ]
+        },
+        "parameters": [
+          {
+            "$ref": "https://raw.githubusercontent.com/totvs/ttalk-standard-message/master/jsonschema/apis/types/totvsApiTypesBase.json#/parameters/Authorization"
+          },
+          {
+            "$ref": "#/components/parameters/code"
+          }
+        ],
+        "requestBody": {
+          "description": "Tabela de preço a ser atualizada.",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "https://raw.githubusercontent.com/totvs/ttalk-standard-message/RetailPriceList/v1/2_006/jsonschema/schemas/PriceListHeaderItem_2_006.json#/definitions/PagedPriceListHeaderItems"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Operação realizada com sucesso!",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "https://raw.githubusercontent.com/totvs/ttalk-standard-message/RetailPriceList/v1/2_006/jsonschema/schemas/PriceListHeaderItem_2_006.json#/definitions/PagedPriceListHeaderItems"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Erro durante a alteração da tabela de preço!",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "https://raw.githubusercontent.com/totvs/ttalk-standard-message/master/jsonschema/apis/types/totvsApiTypesBase.json#/definitions/ErrorModel"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Registro não encontrado!",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "https://raw.githubusercontent.com/totvs/ttalk-standard-message/master/jsonschema/apis/types/totvsApiTypesBase.json#/definitions/ErrorModel"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "api_key": []
+          }
+        ]
+      },
+      "delete": {
+        "tags": [
+          "code"
+        ],
+        "summary": "Exclui uma tabela de preço",
+        "description": "Exclui a tabela de preço conforme dados enviados na requisição.",
+        "operationId": "deletepriceListCode",
+        "x-totvs": {
+          "produtcInformation": [
+            {
+              "product": "Protheus",
+              "available": false,
+              "note": "Este verbo está disponível com os parâmetros Authorization e code.",
+              "minimalVersion": "12.1.23"
+            }
+          ]
+        },
+        "parameters": [
+          {
+            "$ref": "https://raw.githubusercontent.com/totvs/ttalk-standard-message/master/jsonschema/apis/types/totvsApiTypesBase.json#/parameters/Authorization"
+          },
+          {
+            "$ref": "#/components/parameters/code"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Operação realizada com sucesso!",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "https://raw.githubusercontent.com/totvs/ttalk-standard-message/RetailPriceList/v1/2_006/jsonschema/schemas/PriceListHeaderItem_2_006.json#/definitions/PagedPriceListHeaderItems"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Erro durante a exclusão da tabela de preço!",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "https://raw.githubusercontent.com/totvs/ttalk-standard-message/master/jsonschema/apis/types/totvsApiTypesBase.json#/definitions/ErrorModel"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Registro não encontrado!",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "https://raw.githubusercontent.com/totvs/ttalk-standard-message/master/jsonschema/apis/types/totvsApiTypesBase.json#/definitions/ErrorModel"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "api_key": []
+          }
+        ]
+      }
+    },
+    "/retailPriceList/{InternalId}/itensTablePrice/": {
+      "get": {
+        "tags": [
+          "itensTablePriceInternalId"
+        ],
+        "summary": "Retorna os itens da tabela de preço de acordo com o InternalId",
+        "operationId": "getpriceListItemsInternalId",
+        "x-totvs": {
+          "productInformation": [
+            {
+              "product": "Protheus",
+              "available": true,
+              "note": "Este verbo está disponível com os parâmetros Authorization e InternalId.",
+              "minimalVersion": "12.1.23"
+            }
+          ]
+        },
+        "parameters": [
+          {
+            "$ref": "https://raw.githubusercontent.com/totvs/ttalk-standard-message/master/jsonschema/apis/types/totvsApiTypesBase.json#/parameters/Authorization"
+          },
+          {
+            "$ref": "#/components/parameters/code"
+          },
+          {
+            "$ref": "https://raw.githubusercontent.com/totvs/ttalk-standard-message/master/jsonschema/apis/types/totvsApiTypesBase.json#/parameters/Order"
+          },
+          {
+            "$ref": "https://raw.githubusercontent.com/totvs/ttalk-standard-message/master/jsonschema/apis/types/totvsApiTypesBase.json#/parameters/Fields"
+          },
+          {
+            "$ref": "https://raw.githubusercontent.com/totvs/ttalk-standard-message/master/jsonschema/apis/types/totvsApiTypesBase.json#/parameters/Page"
+          },
+          {
+            "$ref": "https://raw.githubusercontent.com/totvs/ttalk-standard-message/master/jsonschema/apis/types/totvsApiTypesBase.json#/parameters/PageSize"
+          },
+          {
+            "$ref": "#/components/parameters/InternalId"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Operação realizada com sucesso!",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "https://raw.githubusercontent.com/totvs/ttalk-standard-message/RetailPriceList/v1/2_006/jsonschema/schemas/PriceListHeaderItem_2_006.json#/definitions/PagedItensTablePrice"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Registro não encontrado!",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "https://raw.githubusercontent.com/totvs/ttalk-standard-message/master/jsonschema/apis/types/totvsApiTypesBase.json#/definitions/ErrorModel"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "api_key": []
+          }
+        ]
+      }
+    },
+    "/retailPriceList/{code}/itensTablePrice/": {
+      "get": {
+        "tags": [
+          "itensTablePrice"
+        ],
+        "summary": "Retorna os itens da tabela de preço de acordo com o seu código",
+        "operationId": "getpriceListItems",
+        "x-totvs": {
+          "productInformation": [
+            {
+              "product": "Protheus",
+              "available": false,
+              "note": "Este verbo está disponível com os parâmetros Authorization e code.",
+              "minimalVersion": "12.1.23"
+            }
+          ]
+        },
+        "parameters": [
+          {
+            "$ref": "https://raw.githubusercontent.com/totvs/ttalk-standard-message/master/jsonschema/apis/types/totvsApiTypesBase.json#/parameters/Authorization"
+          },
+          {
+            "$ref": "#/components/parameters/code"
+          },
+          {
+            "$ref": "https://raw.githubusercontent.com/totvs/ttalk-standard-message/master/jsonschema/apis/types/totvsApiTypesBase.json#/parameters/Order"
+          },
+          {
+            "$ref": "https://raw.githubusercontent.com/totvs/ttalk-standard-message/master/jsonschema/apis/types/totvsApiTypesBase.json#/parameters/Fields"
+          },
+          {
+            "$ref": "https://raw.githubusercontent.com/totvs/ttalk-standard-message/master/jsonschema/apis/types/totvsApiTypesBase.json#/parameters/Page"
+          },
+          {
+            "$ref": "https://raw.githubusercontent.com/totvs/ttalk-standard-message/master/jsonschema/apis/types/totvsApiTypesBase.json#/parameters/PageSize"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Operação realizada com sucesso!",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "https://raw.githubusercontent.com/totvs/ttalk-standard-message/RetailPriceList/v1/2_006/jsonschema/schemas/PriceListHeaderItem_2_006.json#/definitions/PagedItensTablePrice"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Registro não encontrado!",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "https://raw.githubusercontent.com/totvs/ttalk-standard-message/master/jsonschema/apis/types/totvsApiTypesBase.json#/definitions/ErrorModel"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "api_key": []
+          }
+        ]
+      },
+      "post": {
+        "tags": [
+          "itensTablePrice"
+        ],
+        "summary": "Inclui um item na Tabela de Preço",
+        "description": "Inclui um novo item na tabela de preço conforme dados enviados.",
+        "operationId": "postpriceListItems",
+        "x-totvs": {
+          "productInformation": [
+            {
+              "product": "Protheus",
+              "available": false,
+              "note": "Este verbo está disponível com os parâmetros Authorization e code.",
+              "minimalVersion": "12.1.23"
+            }
+          ]
+        },
+        "parameters": [
+          {
+            "$ref": "https://raw.githubusercontent.com/totvs/ttalk-standard-message/master/jsonschema/apis/types/totvsApiTypesBase.json#/parameters/Authorization"
+          },
+          {
+            "$ref": "#/components/parameters/code"
+          }
+        ],
+        "requestBody": {
+          "description": "Tabela de preço a ser incluída.",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "https://raw.githubusercontent.com/totvs/ttalk-standard-message/RetailPriceList/v1/2_006/jsonschema/schemas/PriceListHeaderItem_2_006.json#/definitions/itensTablePrices"
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "Operação realizada com sucesso!",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "https://raw.githubusercontent.com/totvs/ttalk-standard-message/RetailPriceList/v1/2_006/jsonschema/schemas/PriceListHeaderItem_2_006.json#/definitions/PagedItensTablePrice"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Erro durante inclusão da tabela de preço!",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "https://raw.githubusercontent.com/totvs/ttalk-standard-message/master/jsonschema/apis/types/totvsApiTypesBase.json#/definitions/ErrorModel"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "api_key": []
+          }
+        ]
+      }
+    },
+    "/retailPriceList/{InternalId}/itensTablePrice/{itemList}": {
+      "get": {
+        "tags": [
+          "itemTablePriceInternalId"
+        ],
+        "summary": "Retorna um item específico de preço de acordo com o seu código",
+        "operationId": "getpriceListItemListInternalId",
+        "x-totvs": {
+          "productInformation": [
+            {
+              "product": "Protheus",
+              "available": false,
+              "note": "Este verbo está disponível com os parâmetros Authorization e code.",
+              "minimalVersion": "12.1.23"
+            }
+          ]
+        },
+        "parameters": [
+          {
+            "$ref": "https://raw.githubusercontent.com/totvs/ttalk-standard-message/master/jsonschema/apis/types/totvsApiTypesBase.json#/parameters/Authorization"
+          },
+          {
+            "$ref": "#/components/parameters/code"
+          },
+          {
+            "$ref": "#/components/parameters/itemList"
+          },
+          {
+            "$ref": "https://raw.githubusercontent.com/totvs/ttalk-standard-message/master/jsonschema/apis/types/totvsApiTypesBase.json#/parameters/Order"
+          },
+          {
+            "$ref": "https://raw.githubusercontent.com/totvs/ttalk-standard-message/master/jsonschema/apis/types/totvsApiTypesBase.json#/parameters/Fields"
+          },
+          {
+            "$ref": "https://raw.githubusercontent.com/totvs/ttalk-standard-message/master/jsonschema/apis/types/totvsApiTypesBase.json#/parameters/Page"
+          },
+          {
+            "$ref": "https://raw.githubusercontent.com/totvs/ttalk-standard-message/master/jsonschema/apis/types/totvsApiTypesBase.json#/parameters/PageSize"
+          },
+          {
+            "$ref": "#/components/parameters/InternalId"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Operação realizada com sucesso!",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "https://raw.githubusercontent.com/totvs/ttalk-standard-message/RetailPriceList/v1/2_006/jsonschema/schemas/PriceListHeaderItem_2_006.json#/definitions/PagedItensTablePrice"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Registro não encontrado!",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "https://raw.githubusercontent.com/totvs/ttalk-standard-message/master/jsonschema/apis/types/totvsApiTypesBase.json#/definitions/ErrorModel"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "api_key": []
+          }
+        ]
+      }
+    },
+    "/retailPriceList/{code}/itensTablePrice/{itemList}": {
+      "get": {
+        "tags": [
+          "itemTablePrice"
+        ],
+        "summary": "Retorna um item específico de preço de acordo com o seu código",
+        "operationId": "getpriceListItemList",
+        "x-totvs": {
+          "productInformation": [
+            {
+              "product": "Protheus",
+              "available": false,
+              "note": "Este verbo está disponível com os parâmetros Authorization e code.",
+              "minimalVersion": "12.1.23"
+            }
+          ]
+        },
+        "parameters": [
+          {
+            "$ref": "https://raw.githubusercontent.com/totvs/ttalk-standard-message/master/jsonschema/apis/types/totvsApiTypesBase.json#/parameters/Authorization"
+          },
+          {
+            "$ref": "#/components/parameters/code"
+          },
+          {
+            "$ref": "#/components/parameters/itemList"
+          },
+          {
+            "$ref": "https://raw.githubusercontent.com/totvs/ttalk-standard-message/master/jsonschema/apis/types/totvsApiTypesBase.json#/parameters/Order"
+          },
+          {
+            "$ref": "https://raw.githubusercontent.com/totvs/ttalk-standard-message/master/jsonschema/apis/types/totvsApiTypesBase.json#/parameters/Fields"
+          },
+          {
+            "$ref": "https://raw.githubusercontent.com/totvs/ttalk-standard-message/master/jsonschema/apis/types/totvsApiTypesBase.json#/parameters/Page"
+          },
+          {
+            "$ref": "https://raw.githubusercontent.com/totvs/ttalk-standard-message/master/jsonschema/apis/types/totvsApiTypesBase.json#/parameters/PageSize"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Operação realizada com sucesso!",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "https://raw.githubusercontent.com/totvs/ttalk-standard-message/RetailPriceList/v1/2_006/jsonschema/schemas/PriceListHeaderItem_2_006.json#/definitions/PagedItensTablePrice"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Registro não encontrado!",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "https://raw.githubusercontent.com/totvs/ttalk-standard-message/master/jsonschema/apis/types/totvsApiTypesBase.json#/definitions/ErrorModel"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "api_key": []
+          }
+        ]
+      },
+      "put": {
+        "tags": [
+          "itemTablePrice"
+        ],
+        "summary": "Altera um item da tabela de preço",
+        "description": "Atualiza um item da tabela de preço conforme dados enviados na requisição",
+        "operationId": "putpriceListItemList",
+        "x-totvs": {
+          "productInformation": [
+            {
+              "product": "Protheus",
+              "available": false,
+              "note": "Este verbo está disponível com os parâmetros Authorization e code.",
+              "minimalVersion": "12.1.23"
+            }
+          ]
+        },
+        "parameters": [
+          {
+            "$ref": "https://raw.githubusercontent.com/totvs/ttalk-standard-message/master/jsonschema/apis/types/totvsApiTypesBase.json#/parameters/Authorization"
+          },
+          {
+            "$ref": "#/components/parameters/code"
+          },
+          {
+            "$ref": "#/components/parameters/itemList"
+          },
+          {
+            "$ref": "https://raw.githubusercontent.com/totvs/ttalk-standard-message/master/jsonschema/apis/types/totvsApiTypesBase.json#/parameters/Fields"
+          }
+        ],
+        "requestBody": {
+          "description": "Tabela de preço a ser atualizada.",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "https://raw.githubusercontent.com/totvs/ttalk-standard-message/RetailPriceList/v1/2_006/jsonschema/schemas/PriceListHeaderItem_2_006.json#/definitions/itensTablePrices"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Operação realizada com sucesso!",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "https://raw.githubusercontent.com/totvs/ttalk-standard-message/RetailPriceList/v1/2_006/jsonschema/schemas/PriceListHeaderItem_2_006.json#/definitions/PagedItensTablePrice"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Erro ao alterar a tabela de preço!",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "https://raw.githubusercontent.com/totvs/ttalk-standard-message/master/jsonschema/apis/types/totvsApiTypesBase.json#/definitions/ErrorModel"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Registro não encontrado!",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "https://raw.githubusercontent.com/totvs/ttalk-standard-message/master/jsonschema/apis/types/totvsApiTypesBase.json#/definitions/ErrorModel"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "api_key": []
+          }
+        ]
+      },
+      "delete": {
+        "tags": [
+          "itemTablePrice"
+        ],
+        "summary": "Exclui um item da tabela de preço",
+        "description": "Exclui um item da tabela de preço conforme dados enviados na requisição.",
+        "operationId": "deletepriceListItemList",
+        "x-totvs": {
+          "productInformation": [
+            {
+              "product": "Protheus",
+              "available": false,
+              "note": "Este verbo está disponível com os parâmetros Authorization e code.",
+              "minimalVersion": "12.1.23"
+            }
+          ]
+        },
+        "parameters": [
+          {
+            "$ref": "https://raw.githubusercontent.com/totvs/ttalk-standard-message/master/jsonschema/apis/types/totvsApiTypesBase.json#/parameters/Authorization"
+          },
+          {
+            "$ref": "#/components/parameters/code"
+          },
+          {
+            "$ref": "#/components/parameters/itemList"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Operação realizada com sucesso!",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "https://raw.githubusercontent.com/totvs/ttalk-standard-message/RetailPriceList/v1/2_006/jsonschema/schemas/PriceListHeaderItem_2_006.json#/definitions/PagedPriceListHeaderItems"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Erro durante a exclusão da tabela de preço! ",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "https://raw.githubusercontent.com/totvs/ttalk-standard-message/master/jsonschema/apis/types/totvsApiTypesBase.json#/definitions/ErrorModel"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Registro não encontrado!",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "https://raw.githubusercontent.com/totvs/ttalk-standard-message/master/jsonschema/apis/types/totvsApiTypesBase.json#/definitions/ErrorModel"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "api_key": []
+          }
+        ]
+      }
+    }
+  },
+  "components": {
+    "parameters": {
+      "code": {
+        "name": "code",
+        "in": "path",
+        "required": true,
+        "description": "Identificador único da tabela de preço",
+        "schema": {
+          "type": "string"
+        }
+      },
+      "InternalId": {
+        "name": "InternalId",
+        "in": "path",
+        "required": true,
+        "description": "Identificador único da tabela de preço",
+        "schema": {
+          "type": "string"
+        }
+      },
+      "itemList": {
+        "name": "itemList",
+        "in": "path",
+        "required": true,
+        "description": "Identificador do item da tabela de preço",
+        "schema": {
+          "$ref": "https://raw.githubusercontent.com/totvs/ttalk-standard-message/RetailPriceList/v1/2_006/jsonschema/schemas/PriceListHeaderItem_2_006.json#/definitions/itensTablePriceInfo"
+        }
+      }
+    },
+    "schemas": {}
+  }
 }

--- a/jsonschema/apis/RetailPriceList_v1_000.json
+++ b/jsonschema/apis/RetailPriceList_v1_000.json
@@ -165,7 +165,7 @@
         ]
       }
     },
-    "/retailPriceList/{internalId}/itensTablePrice/": {
+    "/retailPriceList/{tableInternalId}/itensTablePrice/": {
       "get": {
         "tags": [
           "itensTablePriceInternalId"
@@ -184,7 +184,7 @@
         },
         "parameters": [
           {
-            "$ref": "#/components/parameters/internalId"
+            "$ref": "#/components/parameters/tableInternalId"
           },
           {
             "$ref": "https://raw.githubusercontent.com/totvs/ttalk-standard-message/master/jsonschema/apis/types/totvsApiTypesBase.json#/parameters/Authorization"
@@ -238,7 +238,16 @@
         "name": "internalId",
         "in": "path",
         "required": true,
-        "description": "Identificador único da tabela de preço",
+        "description": "Identificador único da Tabela de Preço",
+        "schema": {
+          "type": "string"
+        }
+      },
+      "tableInternalId": {
+        "name": "tableInternalId",
+        "in": "path",
+        "required": true,
+        "description": "Identificador único da Tabela de Preço",
         "schema": {
           "type": "string"
         }

--- a/jsonschema/apis/RetailPriceList_v1_000.json
+++ b/jsonschema/apis/RetailPriceList_v1_000.json
@@ -2,7 +2,7 @@
   "openapi": "3.0.1",
   "servers": [
     {
-      "description": "API para cadastro tabela de preços dos produtos TOTVS Varejo",
+      "description": "API para consulta de Preços dos Produtos do Varejo",
       "url": "http://{serverUrl}:{serverHttpPort}/api/retail/v1",
       "variables": {
         "serverUrl": {
@@ -15,7 +15,7 @@
     }
   ],
   "info": {
-    "description": "API para manutenção de tabela de preço para os produtos TOTVS Varejo",
+    "description": "API para consulta de Preços dos Produtos do Varejo",
     "version": "1.000",
     "title": "Tabela de Preços Varejo",
     "contact": {
@@ -26,15 +26,15 @@
     "x-totvs": {
       "messageDocumentation": {
         "name": "RetailPriceList",
-        "descriotion": "API para entidade Tabela de Preço para produtos TOTVS Varejo",
+        "descriotion": "API para consulta de Preços dos Produtos do Varejo",
         "segment": "Varejo"
       },
       "productInformation": [
         {
           "product": "Protheus",
-          "contact": "rafael.pessoa@totvs.com.br",
-          "description": "Cadastro de Tabela de Preços Varejo",
-          "adapter": "RetailPriceList.PRW      -",
+          "contact": "rafael.tenorio@totvs.com.br",
+          "description": "Consulta de Preços - Varejo",
+          "adapter": "",
           "helpUrl": ""
         }
       ]
@@ -44,20 +44,21 @@
     "/retailPriceList": {
       "get": {
         "tags": [
-          "priceListHeaderItem"
+          "priceListHeader"
         ],
-        "summary": "Retorna lista de Tabelas de Preço",
+        "summary": "Retorna uma lista com o cabeçalho de todas as Tabelas de Preço",
         "x-totvs": {
           "productInformation": [
             {
               "product": "Protheus",
               "available": true,
+              "note": "Este verbo esta disponível com todos os parâmetros.",
               "minimalVersion": "12.1.23"
             }
           ]
         },
-        "description": "Retorna lista de Tabela de Preço",
-        "operationId": "getpriceListHeaderItem",
+        "description": "Retorna uma lista com o cabeçalho de todas as Tabelas de Preço",
+        "operationId": "getpriceListHeader",
         "parameters": [
           {
             "$ref": "https://raw.githubusercontent.com/totvs/ttalk-standard-message/master/jsonschema/apis/types/totvsApiTypesBase.json#/parameters/Authorization"
@@ -102,80 +103,21 @@
             "api_key": []
           }
         ]
-      },
-      "post": {
+      }
+    },
+    "/retailPriceList/{internalId}": {
+      "get": {
         "tags": [
-          "priceListHeaderItem"
+          "priceListHeaderInternalId"
         ],
-        "summary": "Inclui uma Tabela de Preço",
+        "summary": "Retorna o cabeçalho de uma única Tabela de Preço a partir do internalId (identificador único da Tabela de Preço)",
+        "operationId": "getpriceListHeaderInternalId",
         "x-totvs": {
           "productInformation": [
             {
               "product": "Protheus",
-              "available": false,
-              "minimalVersion": "12.1.23"
-            }
-          ]
-        },
-        "description": "Inclui uma tabela de preço conforme dados enviados na requisição.",
-        "operationId": "postpriceListHeaderItem",
-        "parameters": [
-          {
-            "$ref": "https://raw.githubusercontent.com/totvs/ttalk-standard-message/master/jsonschema/apis/types/totvsApiTypesBase.json#/parameters/Authorization"
-          }
-        ],
-        "requestBody": {
-          "description": "Tabela de preço a ser incluída.",
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "https://raw.githubusercontent.com/totvs/ttalk-standard-message/RetailPriceList/v1/2_006/jsonschema/schemas/PriceListHeaderItem_2_006.json#/definitions/PagedPriceListHeaderItems"
-              }
-            }
-          }
-        },
-        "responses": {
-          "201": {
-            "description": "Operação realizada com sucesso!",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "https://raw.githubusercontent.com/totvs/ttalk-standard-message/RetailPriceList/v1/2_006/jsonschema/schemas/PriceListHeaderItem_2_006.json#/definitions/PagedPriceListHeaderItems"
-                }
-              }
-            }
-          },
-          "400": {
-            "description": "Erro durante inclusão da tabela de preço!",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "https://raw.githubusercontent.com/totvs/ttalk-standard-message/master/jsonschema/apis/types/totvsApiTypesBase.json#/definitions/ErrorModel"
-                }
-              }
-            }
-          }
-        },
-        "security": [
-          {
-            "api_key": []
-          }
-        ]
-      }
-    },
-    "/retailPriceList/{InternalId}": {
-      "get": {
-        "tags": [
-          "InternalId"
-        ],
-        "summary": "Buscar Tabela de Preço por InternalId que é Identificador único da Tabela de Preço",
-        "operationId": "getpriceListInternalId",
-        "x-totvs": {
-          "produtcInformation": [
-            {
-              "product": "Protheus",
               "available": true,
-              "note": "Este verbo está disponível com os parâmetros Authorization e InternalId.",
+              "note": "Este verbo está disponível com os parâmetros Authorization, Order, Fields e InternalId.",
               "minimalVersion": "12.1.23"
             }
           ]
@@ -185,16 +127,13 @@
             "$ref": "https://raw.githubusercontent.com/totvs/ttalk-standard-message/master/jsonschema/apis/types/totvsApiTypesBase.json#/parameters/Authorization"
           },
           {
-            "$ref": "#/components/parameters/code"
-          },
-          {
             "$ref": "https://raw.githubusercontent.com/totvs/ttalk-standard-message/master/jsonschema/apis/types/totvsApiTypesBase.json#/parameters/Order"
           },
           {
             "$ref": "https://raw.githubusercontent.com/totvs/ttalk-standard-message/master/jsonschema/apis/types/totvsApiTypesBase.json#/parameters/Fields"
           },
           {
-            "$ref": "#/components/parameters/InternalId"
+            "$ref": "#/components/parameters/internalId"
           }
         ],
         "responses": {
@@ -203,7 +142,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "https://raw.githubusercontent.com/totvs/ttalk-standard-message/RetailPriceList/v1/2_006/jsonschema/schemas/PriceListHeaderItem_2_006.json#/definitions/PriceListHeaderItemsInfo"
+                  "$ref": "https://raw.githubusercontent.com/totvs/ttalk-standard-message/RetailPriceList/v1/2_006/jsonschema/schemas/PriceListHeaderItem_2_006.json#/definitions/PriceListHeaderInfo"
                 }
               }
             }
@@ -226,215 +165,19 @@
         ]
       }
     },
-    "/retailPriceList/{code}": {
-      "get": {
-        "tags": [
-          "code"
-        ],
-        "summary": "Retorna a tabela de preço e todos os seus itens de acordo com o seu código",
-        "operationId": "getpriceListCode",
-        "x-totvs": {
-          "produtcInformation": [
-            {
-              "product": "Protheus",
-              "available": false,
-              "note": "Este verbo está disponível com os parâmetros Authorization e code.",
-              "minimalVersion": "12.1.23"
-            }
-          ]
-        },
-        "parameters": [
-          {
-            "$ref": "https://raw.githubusercontent.com/totvs/ttalk-standard-message/master/jsonschema/apis/types/totvsApiTypesBase.json#/parameters/Authorization"
-          },
-          {
-            "$ref": "#/components/parameters/code"
-          },
-          {
-            "$ref": "https://raw.githubusercontent.com/totvs/ttalk-standard-message/master/jsonschema/apis/types/totvsApiTypesBase.json#/parameters/Order"
-          },
-          {
-            "$ref": "https://raw.githubusercontent.com/totvs/ttalk-standard-message/master/jsonschema/apis/types/totvsApiTypesBase.json#/parameters/Fields"
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Operação realizada com sucesso!",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "https://raw.githubusercontent.com/totvs/ttalk-standard-message/RetailPriceList/v1/2_006/jsonschema/schemas/PriceListHeaderItem_2_006.json#/definitions/PriceListHeaderItemsInfo"
-                }
-              }
-            }
-          },
-          "404": {
-            "description": "Registro não encontrado!",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "https://raw.githubusercontent.com/totvs/ttalk-standard-message/master/jsonschema/apis/types/totvsApiTypesBase.json#/definitions/ErrorModel"
-                }
-              }
-            }
-          }
-        },
-        "security": [
-          {
-            "api_key": []
-          }
-        ]
-      },
-      "put": {
-        "tags": [
-          "code"
-        ],
-        "summary": "Altera o Cabeçalho da tabela de preço",
-        "description": "Atualiza o cadastro da tabela de preço conforme dados enviados na requisição",
-        "operationId": "putpriceListCode",
-        "x-totvs": {
-          "produtcInformation": [
-            {
-              "product": "Protheus",
-              "available": false,
-              "note": "Este verbo está disponível com os parâmetros Authorization e code.",
-              "minimalVersion": "12.1.23"
-            }
-          ]
-        },
-        "parameters": [
-          {
-            "$ref": "https://raw.githubusercontent.com/totvs/ttalk-standard-message/master/jsonschema/apis/types/totvsApiTypesBase.json#/parameters/Authorization"
-          },
-          {
-            "$ref": "#/components/parameters/code"
-          }
-        ],
-        "requestBody": {
-          "description": "Tabela de preço a ser atualizada.",
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "https://raw.githubusercontent.com/totvs/ttalk-standard-message/RetailPriceList/v1/2_006/jsonschema/schemas/PriceListHeaderItem_2_006.json#/definitions/PagedPriceListHeaderItems"
-              }
-            }
-          }
-        },
-        "responses": {
-          "200": {
-            "description": "Operação realizada com sucesso!",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "https://raw.githubusercontent.com/totvs/ttalk-standard-message/RetailPriceList/v1/2_006/jsonschema/schemas/PriceListHeaderItem_2_006.json#/definitions/PagedPriceListHeaderItems"
-                }
-              }
-            }
-          },
-          "400": {
-            "description": "Erro durante a alteração da tabela de preço!",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "https://raw.githubusercontent.com/totvs/ttalk-standard-message/master/jsonschema/apis/types/totvsApiTypesBase.json#/definitions/ErrorModel"
-                }
-              }
-            }
-          },
-          "404": {
-            "description": "Registro não encontrado!",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "https://raw.githubusercontent.com/totvs/ttalk-standard-message/master/jsonschema/apis/types/totvsApiTypesBase.json#/definitions/ErrorModel"
-                }
-              }
-            }
-          }
-        },
-        "security": [
-          {
-            "api_key": []
-          }
-        ]
-      },
-      "delete": {
-        "tags": [
-          "code"
-        ],
-        "summary": "Exclui uma tabela de preço",
-        "description": "Exclui a tabela de preço conforme dados enviados na requisição.",
-        "operationId": "deletepriceListCode",
-        "x-totvs": {
-          "produtcInformation": [
-            {
-              "product": "Protheus",
-              "available": false,
-              "note": "Este verbo está disponível com os parâmetros Authorization e code.",
-              "minimalVersion": "12.1.23"
-            }
-          ]
-        },
-        "parameters": [
-          {
-            "$ref": "https://raw.githubusercontent.com/totvs/ttalk-standard-message/master/jsonschema/apis/types/totvsApiTypesBase.json#/parameters/Authorization"
-          },
-          {
-            "$ref": "#/components/parameters/code"
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Operação realizada com sucesso!",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "https://raw.githubusercontent.com/totvs/ttalk-standard-message/RetailPriceList/v1/2_006/jsonschema/schemas/PriceListHeaderItem_2_006.json#/definitions/PagedPriceListHeaderItems"
-                }
-              }
-            }
-          },
-          "400": {
-            "description": "Erro durante a exclusão da tabela de preço!",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "https://raw.githubusercontent.com/totvs/ttalk-standard-message/master/jsonschema/apis/types/totvsApiTypesBase.json#/definitions/ErrorModel"
-                }
-              }
-            }
-          },
-          "404": {
-            "description": "Registro não encontrado!",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "https://raw.githubusercontent.com/totvs/ttalk-standard-message/master/jsonschema/apis/types/totvsApiTypesBase.json#/definitions/ErrorModel"
-                }
-              }
-            }
-          }
-        },
-        "security": [
-          {
-            "api_key": []
-          }
-        ]
-      }
-    },
-    "/retailPriceList/{InternalId}/itensTablePrice/": {
+    "/retailPriceList/{internalId}/itensTablePrice/": {
       "get": {
         "tags": [
           "itensTablePriceInternalId"
         ],
-        "summary": "Retorna os itens da tabela de preço de acordo com o InternalId",
-        "operationId": "getpriceListItemsInternalId",
+        "summary": "Retorna todos os itens de uma única Tabela de Preço a partir do internalId (identificador único da Tabela de Preço)",
+        "operationId": "getitensTablePriceInternalId",
         "x-totvs": {
           "productInformation": [
             {
               "product": "Protheus",
               "available": true,
-              "note": "Este verbo está disponível com os parâmetros Authorization e InternalId.",
+              "note": "Este verbo esta disponível com todos os parâmetros.",
               "minimalVersion": "12.1.23"
             }
           ]
@@ -442,9 +185,6 @@
         "parameters": [
           {
             "$ref": "https://raw.githubusercontent.com/totvs/ttalk-standard-message/master/jsonschema/apis/types/totvsApiTypesBase.json#/parameters/Authorization"
-          },
-          {
-            "$ref": "#/components/parameters/code"
           },
           {
             "$ref": "https://raw.githubusercontent.com/totvs/ttalk-standard-message/master/jsonschema/apis/types/totvsApiTypesBase.json#/parameters/Order"
@@ -459,7 +199,7 @@
             "$ref": "https://raw.githubusercontent.com/totvs/ttalk-standard-message/master/jsonschema/apis/types/totvsApiTypesBase.json#/parameters/PageSize"
           },
           {
-            "$ref": "#/components/parameters/InternalId"
+            "$ref": "#/components/parameters/internalId"
           }
         ],
         "responses": {
@@ -469,421 +209,6 @@
               "application/json": {
                 "schema": {
                   "$ref": "https://raw.githubusercontent.com/totvs/ttalk-standard-message/RetailPriceList/v1/2_006/jsonschema/schemas/PriceListHeaderItem_2_006.json#/definitions/PagedItensTablePrice"
-                }
-              }
-            }
-          },
-          "404": {
-            "description": "Registro não encontrado!",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "https://raw.githubusercontent.com/totvs/ttalk-standard-message/master/jsonschema/apis/types/totvsApiTypesBase.json#/definitions/ErrorModel"
-                }
-              }
-            }
-          }
-        },
-        "security": [
-          {
-            "api_key": []
-          }
-        ]
-      }
-    },
-    "/retailPriceList/{code}/itensTablePrice/": {
-      "get": {
-        "tags": [
-          "itensTablePrice"
-        ],
-        "summary": "Retorna os itens da tabela de preço de acordo com o seu código",
-        "operationId": "getpriceListItems",
-        "x-totvs": {
-          "productInformation": [
-            {
-              "product": "Protheus",
-              "available": false,
-              "note": "Este verbo está disponível com os parâmetros Authorization e code.",
-              "minimalVersion": "12.1.23"
-            }
-          ]
-        },
-        "parameters": [
-          {
-            "$ref": "https://raw.githubusercontent.com/totvs/ttalk-standard-message/master/jsonschema/apis/types/totvsApiTypesBase.json#/parameters/Authorization"
-          },
-          {
-            "$ref": "#/components/parameters/code"
-          },
-          {
-            "$ref": "https://raw.githubusercontent.com/totvs/ttalk-standard-message/master/jsonschema/apis/types/totvsApiTypesBase.json#/parameters/Order"
-          },
-          {
-            "$ref": "https://raw.githubusercontent.com/totvs/ttalk-standard-message/master/jsonschema/apis/types/totvsApiTypesBase.json#/parameters/Fields"
-          },
-          {
-            "$ref": "https://raw.githubusercontent.com/totvs/ttalk-standard-message/master/jsonschema/apis/types/totvsApiTypesBase.json#/parameters/Page"
-          },
-          {
-            "$ref": "https://raw.githubusercontent.com/totvs/ttalk-standard-message/master/jsonschema/apis/types/totvsApiTypesBase.json#/parameters/PageSize"
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Operação realizada com sucesso!",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "https://raw.githubusercontent.com/totvs/ttalk-standard-message/RetailPriceList/v1/2_006/jsonschema/schemas/PriceListHeaderItem_2_006.json#/definitions/PagedItensTablePrice"
-                }
-              }
-            }
-          },
-          "404": {
-            "description": "Registro não encontrado!",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "https://raw.githubusercontent.com/totvs/ttalk-standard-message/master/jsonschema/apis/types/totvsApiTypesBase.json#/definitions/ErrorModel"
-                }
-              }
-            }
-          }
-        },
-        "security": [
-          {
-            "api_key": []
-          }
-        ]
-      },
-      "post": {
-        "tags": [
-          "itensTablePrice"
-        ],
-        "summary": "Inclui um item na Tabela de Preço",
-        "description": "Inclui um novo item na tabela de preço conforme dados enviados.",
-        "operationId": "postpriceListItems",
-        "x-totvs": {
-          "productInformation": [
-            {
-              "product": "Protheus",
-              "available": false,
-              "note": "Este verbo está disponível com os parâmetros Authorization e code.",
-              "minimalVersion": "12.1.23"
-            }
-          ]
-        },
-        "parameters": [
-          {
-            "$ref": "https://raw.githubusercontent.com/totvs/ttalk-standard-message/master/jsonschema/apis/types/totvsApiTypesBase.json#/parameters/Authorization"
-          },
-          {
-            "$ref": "#/components/parameters/code"
-          }
-        ],
-        "requestBody": {
-          "description": "Tabela de preço a ser incluída.",
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "https://raw.githubusercontent.com/totvs/ttalk-standard-message/RetailPriceList/v1/2_006/jsonschema/schemas/PriceListHeaderItem_2_006.json#/definitions/itensTablePrices"
-              }
-            }
-          }
-        },
-        "responses": {
-          "201": {
-            "description": "Operação realizada com sucesso!",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "https://raw.githubusercontent.com/totvs/ttalk-standard-message/RetailPriceList/v1/2_006/jsonschema/schemas/PriceListHeaderItem_2_006.json#/definitions/PagedItensTablePrice"
-                }
-              }
-            }
-          },
-          "400": {
-            "description": "Erro durante inclusão da tabela de preço!",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "https://raw.githubusercontent.com/totvs/ttalk-standard-message/master/jsonschema/apis/types/totvsApiTypesBase.json#/definitions/ErrorModel"
-                }
-              }
-            }
-          }
-        },
-        "security": [
-          {
-            "api_key": []
-          }
-        ]
-      }
-    },
-    "/retailPriceList/{InternalId}/itensTablePrice/{itemList}": {
-      "get": {
-        "tags": [
-          "itemTablePriceInternalId"
-        ],
-        "summary": "Retorna um item específico de preço de acordo com o seu código",
-        "operationId": "getpriceListItemListInternalId",
-        "x-totvs": {
-          "productInformation": [
-            {
-              "product": "Protheus",
-              "available": false,
-              "note": "Este verbo está disponível com os parâmetros Authorization e code.",
-              "minimalVersion": "12.1.23"
-            }
-          ]
-        },
-        "parameters": [
-          {
-            "$ref": "https://raw.githubusercontent.com/totvs/ttalk-standard-message/master/jsonschema/apis/types/totvsApiTypesBase.json#/parameters/Authorization"
-          },
-          {
-            "$ref": "#/components/parameters/code"
-          },
-          {
-            "$ref": "#/components/parameters/itemList"
-          },
-          {
-            "$ref": "https://raw.githubusercontent.com/totvs/ttalk-standard-message/master/jsonschema/apis/types/totvsApiTypesBase.json#/parameters/Order"
-          },
-          {
-            "$ref": "https://raw.githubusercontent.com/totvs/ttalk-standard-message/master/jsonschema/apis/types/totvsApiTypesBase.json#/parameters/Fields"
-          },
-          {
-            "$ref": "https://raw.githubusercontent.com/totvs/ttalk-standard-message/master/jsonschema/apis/types/totvsApiTypesBase.json#/parameters/Page"
-          },
-          {
-            "$ref": "https://raw.githubusercontent.com/totvs/ttalk-standard-message/master/jsonschema/apis/types/totvsApiTypesBase.json#/parameters/PageSize"
-          },
-          {
-            "$ref": "#/components/parameters/InternalId"
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Operação realizada com sucesso!",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "https://raw.githubusercontent.com/totvs/ttalk-standard-message/RetailPriceList/v1/2_006/jsonschema/schemas/PriceListHeaderItem_2_006.json#/definitions/PagedItensTablePrice"
-                }
-              }
-            }
-          },
-          "404": {
-            "description": "Registro não encontrado!",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "https://raw.githubusercontent.com/totvs/ttalk-standard-message/master/jsonschema/apis/types/totvsApiTypesBase.json#/definitions/ErrorModel"
-                }
-              }
-            }
-          }
-        },
-        "security": [
-          {
-            "api_key": []
-          }
-        ]
-      }
-    },
-    "/retailPriceList/{code}/itensTablePrice/{itemList}": {
-      "get": {
-        "tags": [
-          "itemTablePrice"
-        ],
-        "summary": "Retorna um item específico de preço de acordo com o seu código",
-        "operationId": "getpriceListItemList",
-        "x-totvs": {
-          "productInformation": [
-            {
-              "product": "Protheus",
-              "available": false,
-              "note": "Este verbo está disponível com os parâmetros Authorization e code.",
-              "minimalVersion": "12.1.23"
-            }
-          ]
-        },
-        "parameters": [
-          {
-            "$ref": "https://raw.githubusercontent.com/totvs/ttalk-standard-message/master/jsonschema/apis/types/totvsApiTypesBase.json#/parameters/Authorization"
-          },
-          {
-            "$ref": "#/components/parameters/code"
-          },
-          {
-            "$ref": "#/components/parameters/itemList"
-          },
-          {
-            "$ref": "https://raw.githubusercontent.com/totvs/ttalk-standard-message/master/jsonschema/apis/types/totvsApiTypesBase.json#/parameters/Order"
-          },
-          {
-            "$ref": "https://raw.githubusercontent.com/totvs/ttalk-standard-message/master/jsonschema/apis/types/totvsApiTypesBase.json#/parameters/Fields"
-          },
-          {
-            "$ref": "https://raw.githubusercontent.com/totvs/ttalk-standard-message/master/jsonschema/apis/types/totvsApiTypesBase.json#/parameters/Page"
-          },
-          {
-            "$ref": "https://raw.githubusercontent.com/totvs/ttalk-standard-message/master/jsonschema/apis/types/totvsApiTypesBase.json#/parameters/PageSize"
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Operação realizada com sucesso!",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "https://raw.githubusercontent.com/totvs/ttalk-standard-message/RetailPriceList/v1/2_006/jsonschema/schemas/PriceListHeaderItem_2_006.json#/definitions/PagedItensTablePrice"
-                }
-              }
-            }
-          },
-          "404": {
-            "description": "Registro não encontrado!",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "https://raw.githubusercontent.com/totvs/ttalk-standard-message/master/jsonschema/apis/types/totvsApiTypesBase.json#/definitions/ErrorModel"
-                }
-              }
-            }
-          }
-        },
-        "security": [
-          {
-            "api_key": []
-          }
-        ]
-      },
-      "put": {
-        "tags": [
-          "itemTablePrice"
-        ],
-        "summary": "Altera um item da tabela de preço",
-        "description": "Atualiza um item da tabela de preço conforme dados enviados na requisição",
-        "operationId": "putpriceListItemList",
-        "x-totvs": {
-          "productInformation": [
-            {
-              "product": "Protheus",
-              "available": false,
-              "note": "Este verbo está disponível com os parâmetros Authorization e code.",
-              "minimalVersion": "12.1.23"
-            }
-          ]
-        },
-        "parameters": [
-          {
-            "$ref": "https://raw.githubusercontent.com/totvs/ttalk-standard-message/master/jsonschema/apis/types/totvsApiTypesBase.json#/parameters/Authorization"
-          },
-          {
-            "$ref": "#/components/parameters/code"
-          },
-          {
-            "$ref": "#/components/parameters/itemList"
-          },
-          {
-            "$ref": "https://raw.githubusercontent.com/totvs/ttalk-standard-message/master/jsonschema/apis/types/totvsApiTypesBase.json#/parameters/Fields"
-          }
-        ],
-        "requestBody": {
-          "description": "Tabela de preço a ser atualizada.",
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "https://raw.githubusercontent.com/totvs/ttalk-standard-message/RetailPriceList/v1/2_006/jsonschema/schemas/PriceListHeaderItem_2_006.json#/definitions/itensTablePrices"
-              }
-            }
-          }
-        },
-        "responses": {
-          "200": {
-            "description": "Operação realizada com sucesso!",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "https://raw.githubusercontent.com/totvs/ttalk-standard-message/RetailPriceList/v1/2_006/jsonschema/schemas/PriceListHeaderItem_2_006.json#/definitions/PagedItensTablePrice"
-                }
-              }
-            }
-          },
-          "400": {
-            "description": "Erro ao alterar a tabela de preço!",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "https://raw.githubusercontent.com/totvs/ttalk-standard-message/master/jsonschema/apis/types/totvsApiTypesBase.json#/definitions/ErrorModel"
-                }
-              }
-            }
-          },
-          "404": {
-            "description": "Registro não encontrado!",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "https://raw.githubusercontent.com/totvs/ttalk-standard-message/master/jsonschema/apis/types/totvsApiTypesBase.json#/definitions/ErrorModel"
-                }
-              }
-            }
-          }
-        },
-        "security": [
-          {
-            "api_key": []
-          }
-        ]
-      },
-      "delete": {
-        "tags": [
-          "itemTablePrice"
-        ],
-        "summary": "Exclui um item da tabela de preço",
-        "description": "Exclui um item da tabela de preço conforme dados enviados na requisição.",
-        "operationId": "deletepriceListItemList",
-        "x-totvs": {
-          "productInformation": [
-            {
-              "product": "Protheus",
-              "available": false,
-              "note": "Este verbo está disponível com os parâmetros Authorization e code.",
-              "minimalVersion": "12.1.23"
-            }
-          ]
-        },
-        "parameters": [
-          {
-            "$ref": "https://raw.githubusercontent.com/totvs/ttalk-standard-message/master/jsonschema/apis/types/totvsApiTypesBase.json#/parameters/Authorization"
-          },
-          {
-            "$ref": "#/components/parameters/code"
-          },
-          {
-            "$ref": "#/components/parameters/itemList"
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Operação realizada com sucesso!",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "https://raw.githubusercontent.com/totvs/ttalk-standard-message/RetailPriceList/v1/2_006/jsonschema/schemas/PriceListHeaderItem_2_006.json#/definitions/PagedPriceListHeaderItems"
-                }
-              }
-            }
-          },
-          "400": {
-            "description": "Erro durante a exclusão da tabela de preço! ",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "https://raw.githubusercontent.com/totvs/ttalk-standard-message/master/jsonschema/apis/types/totvsApiTypesBase.json#/definitions/ErrorModel"
                 }
               }
             }
@@ -909,31 +234,13 @@
   },
   "components": {
     "parameters": {
-      "code": {
-        "name": "code",
+      "internalId": {
+        "name": "internalId",
         "in": "path",
         "required": true,
         "description": "Identificador único da tabela de preço",
         "schema": {
           "type": "string"
-        }
-      },
-      "InternalId": {
-        "name": "InternalId",
-        "in": "path",
-        "required": true,
-        "description": "Identificador único da tabela de preço",
-        "schema": {
-          "type": "string"
-        }
-      },
-      "itemList": {
-        "name": "itemList",
-        "in": "path",
-        "required": true,
-        "description": "Identificador do item da tabela de preço",
-        "schema": {
-          "$ref": "https://raw.githubusercontent.com/totvs/ttalk-standard-message/RetailPriceList/v1/2_006/jsonschema/schemas/PriceListHeaderItem_2_006.json#/definitions/itensTablePriceInfo"
         }
       }
     },

--- a/jsonschema/apis/RetailPriceList_v1_000.json
+++ b/jsonschema/apis/RetailPriceList_v1_000.json
@@ -124,6 +124,9 @@
         },
         "parameters": [
           {
+            "$ref": "#/components/parameters/internalId"
+          },
+          {
             "$ref": "https://raw.githubusercontent.com/totvs/ttalk-standard-message/master/jsonschema/apis/types/totvsApiTypesBase.json#/parameters/Authorization"
           },
           {
@@ -131,9 +134,6 @@
           },
           {
             "$ref": "https://raw.githubusercontent.com/totvs/ttalk-standard-message/master/jsonschema/apis/types/totvsApiTypesBase.json#/parameters/Fields"
-          },
-          {
-            "$ref": "#/components/parameters/internalId"
           }
         ],
         "responses": {
@@ -184,6 +184,9 @@
         },
         "parameters": [
           {
+            "$ref": "#/components/parameters/internalId"
+          },
+          {
             "$ref": "https://raw.githubusercontent.com/totvs/ttalk-standard-message/master/jsonschema/apis/types/totvsApiTypesBase.json#/parameters/Authorization"
           },
           {
@@ -197,9 +200,6 @@
           },
           {
             "$ref": "https://raw.githubusercontent.com/totvs/ttalk-standard-message/master/jsonschema/apis/types/totvsApiTypesBase.json#/parameters/PageSize"
-          },
-          {
-            "$ref": "#/components/parameters/internalId"
           }
         ],
         "responses": {

--- a/jsonschema/apis/RetailPriceList_v1_000.json
+++ b/jsonschema/apis/RetailPriceList_v1_000.json
@@ -1,0 +1,942 @@
+{
+	"openapi": "3.0.1",
+	"servers": [
+		{
+			"description": "API para cadastro tabela de preços dos produtos TOTVS Varejo",
+			"url": "http://{serverUrl}:{serverHttpPort}/api/retail/v1",
+			"variables": {
+				"serverUrl": {
+					"default": "localhost"
+				},
+				"serverHttpPort": {
+					"default": "8051"
+				}
+			}
+		}
+	],
+	"info": {
+		"description": "API para manutenção de tabela de preço para os produtos TOTVS Varejo",
+		"version": "1.000",
+		"title": "Tabela de Preços Varejo",
+		"contact": {
+			"name": "T-Talk",
+			"url": "api.totvs.com.br",
+			"email": "comiteintegracao@totvs.com.br"
+		},
+		"x-totvs": {
+			"messageDocumentation": {
+				"name": "RetailPriceList",
+				"descriotion": "API para entidade Tabela de Preço para produtos TOTVS Varejo",
+				"segment": "Varejo"
+			},
+			"productInformation": [
+				{
+					"product": "Protheus",
+					"contact": "rafael.pessoa@totvs.com.br",
+					"description": "Cadastro de Tabela de Preços Varejo",
+					"adapter": "RetailPriceList.PRW      -",
+					"helpUrl": ""
+				}
+			]
+		}
+	},
+	"paths": {
+		"/retailPriceList": {
+			"get": {
+				"tags": [
+					"priceListHeaderItem"
+				],
+				"summary": "Retorna lista de Tabelas de Preço",
+				"x-totvs": {
+					"productInformation": [
+						{
+							"product": "Protheus",
+							"available": true,
+							"minimalVersion": "12.1.23"
+						}
+					]
+				},
+				"description": "Retorna lista de Tabela de Preço",
+				"operationId": "getpriceListHeaderItem",
+				"parameters": [
+					{
+						"$ref": "https://raw.githubusercontent.com/totvs/ttalk-standard-message/master/jsonschema/apis/types/totvsApiTypesBase.json#/parameters/Authorization"
+					},
+					{
+						"$ref": "https://raw.githubusercontent.com/totvs/ttalk-standard-message/master/jsonschema/apis/types/totvsApiTypesBase.json#/parameters/Order"
+					},
+					{
+						"$ref": "https://raw.githubusercontent.com/totvs/ttalk-standard-message/master/jsonschema/apis/types/totvsApiTypesBase.json#/parameters/Fields"
+					},
+					{
+						"$ref": "https://raw.githubusercontent.com/totvs/ttalk-standard-message/master/jsonschema/apis/types/totvsApiTypesBase.json#/parameters/Page"
+					},
+					{
+						"$ref": "https://raw.githubusercontent.com/totvs/ttalk-standard-message/master/jsonschema/apis/types/totvsApiTypesBase.json#/parameters/PageSize"
+					}
+				],
+				"responses": {
+					"200": {
+						"description": "Operação realizada com sucesso!",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "https://raw.githubusercontent.com/totvs/ttalk-standard-message/RetailPriceList/v1/2_006/jsonschema/schemas/PriceListHeaderItem_2_006.json#/definitions/PagedPriceListHeader"
+								}
+							}
+						}
+					},
+					"404": {
+						"description": "Registro não encontrado!",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "https://raw.githubusercontent.com/totvs/ttalk-standard-message/master/jsonschema/apis/types/totvsApiTypesBase.json#/definitions/ErrorModel"
+								}
+							}
+						}
+					}
+				},
+				"security": [
+					{
+						"api_key": []
+					}
+				]
+			},
+			"post": {
+				"tags": [
+					"priceListHeaderItem"
+				],
+				"summary": "Inclui uma Tabela de Preço",
+				"x-totvs": {
+					"productInformation": [
+						{
+							"product": "Protheus",
+							"available": false,
+							"minimalVersion": "12.1.23"
+						}
+					]
+				},
+				"description": "Inclui uma tabela de preço conforme dados enviados na requisição.",
+				"operationId": "postpriceListHeaderItem",
+				"parameters": [
+					{
+						"$ref": "https://raw.githubusercontent.com/totvs/ttalk-standard-message/master/jsonschema/apis/types/totvsApiTypesBase.json#/parameters/Authorization"
+					}
+				],
+				"requestBody": {
+					"description": "Tabela de preço a ser incluída.",
+					"content": {
+						"application/json": {
+							"schema": {
+								"$ref": "https://raw.githubusercontent.com/totvs/ttalk-standard-message/RetailPriceList/v1/2_006/jsonschema/schemas/PriceListHeaderItem_2_006.json#/definitions/PagedPriceListHeaderItems"
+							}
+						}
+					}
+				},
+				"responses": {
+					"201": {
+						"description": "Operação realizada com sucesso!",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "https://raw.githubusercontent.com/totvs/ttalk-standard-message/RetailPriceList/v1/2_006/jsonschema/schemas/PriceListHeaderItem_2_006.json#/definitions/PagedPriceListHeaderItems"
+								}
+							}
+						}
+					},
+					"400": {
+						"description": "Erro durante inclusão da tabela de preço!",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "https://raw.githubusercontent.com/totvs/ttalk-standard-message/master/jsonschema/apis/types/totvsApiTypesBase.json#/definitions/ErrorModel"
+								}
+							}
+						}
+					}
+				},
+				"security": [
+					{
+						"api_key": []
+					}
+				]
+			}
+		},
+		"/retailPriceList/{InternalId}": {
+			"get": {
+				"tags": [
+					"InternalId"
+				],
+				"summary": "Buscar Tabela de Preço por InternalId que é Identificador único da Tabela de Preço",
+				"operationId": "getpriceListInternalId",
+				"x-totvs": {
+					"produtcInformation": [
+						{
+							"product": "Protheus",
+							"available": true,
+							"note": "Este verbo está disponível com os parâmetros Authorization e InternalId.",
+							"minimalVersion": "12.1.23"
+						}
+					]
+				},
+				"parameters": [
+					{
+						"$ref": "https://raw.githubusercontent.com/totvs/ttalk-standard-message/master/jsonschema/apis/types/totvsApiTypesBase.json#/parameters/Authorization"
+					},
+					{
+						"$ref": "#/components/parameters/code"
+					},
+					{
+						"$ref": "https://raw.githubusercontent.com/totvs/ttalk-standard-message/master/jsonschema/apis/types/totvsApiTypesBase.json#/parameters/Order"
+					},
+					{
+						"$ref": "https://raw.githubusercontent.com/totvs/ttalk-standard-message/master/jsonschema/apis/types/totvsApiTypesBase.json#/parameters/Fields"
+					},
+					{
+						"$ref": "#/components/parameters/InternalId"
+					}
+				],
+				"responses": {
+					"200": {
+						"description": "Operação realizada com sucesso!",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "https://raw.githubusercontent.com/totvs/ttalk-standard-message/RetailPriceList/v1/2_006/jsonschema/schemas/PriceListHeaderItem_2_006.json#/definitions/PagedPriceListHeaderItems"
+								}
+							}
+						}
+					},
+					"404": {
+						"description": "Registro não encontrado!",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "https://raw.githubusercontent.com/totvs/ttalk-standard-message/master/jsonschema/apis/types/totvsApiTypesBase.json#/definitions/ErrorModel"
+								}
+							}
+						}
+					}
+				},
+				"security": [
+					{
+						"api_key": []
+					}
+				]
+			}
+		},
+		"/retailPriceList/{code}": {
+			"get": {
+				"tags": [
+					"code"
+				],
+				"summary": "Retorna a tabela de preço e todos os seus itens de acordo com o seu código",
+				"operationId": "getpriceListCode",
+				"x-totvs": {
+					"produtcInformation": [
+						{
+							"product": "Protheus",
+							"available": false,
+							"note": "Este verbo está disponível com os parâmetros Authorization e code.",
+							"minimalVersion": "12.1.23"
+						}
+					]
+				},
+				"parameters": [
+					{
+						"$ref": "https://raw.githubusercontent.com/totvs/ttalk-standard-message/master/jsonschema/apis/types/totvsApiTypesBase.json#/parameters/Authorization"
+					},
+					{
+						"$ref": "#/components/parameters/code"
+					},
+					{
+						"$ref": "https://raw.githubusercontent.com/totvs/ttalk-standard-message/master/jsonschema/apis/types/totvsApiTypesBase.json#/parameters/Order"
+					},
+					{
+						"$ref": "https://raw.githubusercontent.com/totvs/ttalk-standard-message/master/jsonschema/apis/types/totvsApiTypesBase.json#/parameters/Fields"
+					}
+				],
+				"responses": {
+					"200": {
+						"description": "Operação realizada com sucesso!",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "https://raw.githubusercontent.com/totvs/ttalk-standard-message/RetailPriceList/v1/2_006/jsonschema/schemas/PriceListHeaderItem_2_006.json#/definitions/PagedPriceListHeaderItems"
+								}
+							}
+						}
+					},
+					"404": {
+						"description": "Registro não encontrado!",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "https://raw.githubusercontent.com/totvs/ttalk-standard-message/master/jsonschema/apis/types/totvsApiTypesBase.json#/definitions/ErrorModel"
+								}
+							}
+						}
+					}
+				},
+				"security": [
+					{
+						"api_key": []
+					}
+				]
+			},
+			"put": {
+				"tags": [
+					"code"
+				],
+				"summary": "Altera o Cabeçalho da tabela de preço",
+				"description": "Atualiza o cadastro da tabela de preço conforme dados enviados na requisição",
+				"operationId": "putpriceListCode",
+				"x-totvs": {
+					"produtcInformation": [
+						{
+							"product": "Protheus",
+							"available": false,
+							"note": "Este verbo está disponível com os parâmetros Authorization e code.",
+							"minimalVersion": "12.1.23"
+						}
+					]
+				},
+				"parameters": [
+					{
+						"$ref": "https://raw.githubusercontent.com/totvs/ttalk-standard-message/master/jsonschema/apis/types/totvsApiTypesBase.json#/parameters/Authorization"
+					},
+					{
+						"$ref": "#/components/parameters/code"
+					}
+				],
+				"requestBody": {
+					"description": "Tabela de preço a ser atualizada.",
+					"content": {
+						"application/json": {
+							"schema": {
+								"$ref": "https://raw.githubusercontent.com/totvs/ttalk-standard-message/RetailPriceList/v1/2_006/jsonschema/schemas/PriceListHeaderItem_2_006.json#/definitions/PagedPriceListHeaderItems"
+							}
+						}
+					}
+				},
+				"responses": {
+					"200": {
+						"description": "Operação realizada com sucesso!",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "https://raw.githubusercontent.com/totvs/ttalk-standard-message/RetailPriceList/v1/2_006/jsonschema/schemas/PriceListHeaderItem_2_006.json#/definitions/PagedPriceListHeaderItems"
+								}
+							}
+						}
+					},
+					"400": {
+						"description": "Erro durante a alteração da tabela de preço!",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "https://raw.githubusercontent.com/totvs/ttalk-standard-message/master/jsonschema/apis/types/totvsApiTypesBase.json#/definitions/ErrorModel"
+								}
+							}
+						}
+					},
+					"404": {
+						"description": "Registro não encontrado!",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "https://raw.githubusercontent.com/totvs/ttalk-standard-message/master/jsonschema/apis/types/totvsApiTypesBase.json#/definitions/ErrorModel"
+								}
+							}
+						}
+					}
+				},
+				"security": [
+					{
+						"api_key": []
+					}
+				]
+			},
+			"delete": {
+				"tags": [
+					"code"
+				],
+				"summary": "Exclui uma tabela de preço",
+				"description": "Exclui a tabela de preço conforme dados enviados na requisição.",
+				"operationId": "deletepriceListCode",
+				"x-totvs": {
+					"produtcInformation": [
+						{
+							"product": "Protheus",
+							"available": false,
+							"note": "Este verbo está disponível com os parâmetros Authorization e code.",
+							"minimalVersion": "12.1.23"
+						}
+					]
+				},
+				"parameters": [
+					{
+						"$ref": "https://raw.githubusercontent.com/totvs/ttalk-standard-message/master/jsonschema/apis/types/totvsApiTypesBase.json#/parameters/Authorization"
+					},
+					{
+						"$ref": "#/components/parameters/code"
+					}
+				],
+				"responses": {
+					"200": {
+						"description": "Operação realizada com sucesso!",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "https://raw.githubusercontent.com/totvs/ttalk-standard-message/RetailPriceList/v1/2_006/jsonschema/schemas/PriceListHeaderItem_2_006.json#/definitions/PagedPriceListHeaderItems"
+								}
+							}
+						}
+					},
+					"400": {
+						"description": "Erro durante a exclusão da tabela de preço!",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "https://raw.githubusercontent.com/totvs/ttalk-standard-message/master/jsonschema/apis/types/totvsApiTypesBase.json#/definitions/ErrorModel"
+								}
+							}
+						}
+					},
+					"404": {
+						"description": "Registro não encontrado!",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "https://raw.githubusercontent.com/totvs/ttalk-standard-message/master/jsonschema/apis/types/totvsApiTypesBase.json#/definitions/ErrorModel"
+								}
+							}
+						}
+					}
+				},
+				"security": [
+					{
+						"api_key": []
+					}
+				]
+			}
+		},
+		"/retailPriceList/{InternalId}/itensTablePrice/": {
+			"get": {
+				"tags": [
+					"itensTablePriceInternalId"
+				],
+				"summary": "Retorna os itens da tabela de preço de acordo com o InternalId",
+				"operationId": "getpriceListItemsInternalId",
+				"x-totvs": {
+					"productInformation": [
+						{
+							"product": "Protheus",
+							"available": true,
+							"note": "Este verbo está disponível com os parâmetros Authorization e InternalId.",
+							"minimalVersion": "12.1.23"
+						}
+					]
+				},
+				"parameters": [
+					{
+						"$ref": "https://raw.githubusercontent.com/totvs/ttalk-standard-message/master/jsonschema/apis/types/totvsApiTypesBase.json#/parameters/Authorization"
+					},
+					{
+						"$ref": "#/components/parameters/code"
+					},
+					{
+						"$ref": "https://raw.githubusercontent.com/totvs/ttalk-standard-message/master/jsonschema/apis/types/totvsApiTypesBase.json#/parameters/Order"
+					},
+					{
+						"$ref": "https://raw.githubusercontent.com/totvs/ttalk-standard-message/master/jsonschema/apis/types/totvsApiTypesBase.json#/parameters/Fields"
+					},
+					{
+						"$ref": "https://raw.githubusercontent.com/totvs/ttalk-standard-message/master/jsonschema/apis/types/totvsApiTypesBase.json#/parameters/Page"
+					},
+					{
+						"$ref": "https://raw.githubusercontent.com/totvs/ttalk-standard-message/master/jsonschema/apis/types/totvsApiTypesBase.json#/parameters/PageSize"
+					},
+					{
+						"$ref": "#/components/parameters/InternalId"
+					}
+				],
+				"responses": {
+					"200": {
+						"description": "Operação realizada com sucesso!",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "https://raw.githubusercontent.com/totvs/ttalk-standard-message/RetailPriceList/v1/2_006/jsonschema/schemas/PriceListHeaderItem_2_006.json#/definitions/PagedItensTablePrice"
+								}
+							}
+						}
+					},
+					"404": {
+						"description": "Registro não encontrado!",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "https://raw.githubusercontent.com/totvs/ttalk-standard-message/master/jsonschema/apis/types/totvsApiTypesBase.json#/definitions/ErrorModel"
+								}
+							}
+						}
+					}
+				},
+				"security": [
+					{
+						"api_key": []
+					}
+				]
+			}
+		},
+		"/retailPriceList/{code}/itensTablePrice/": {
+			"get": {
+				"tags": [
+					"itensTablePrice"
+				],
+				"summary": "Retorna os itens da tabela de preço de acordo com o seu código",
+				"operationId": "getpriceListItems",
+				"x-totvs": {
+					"productInformation": [
+						{
+							"product": "Protheus",
+							"available": false,
+							"note": "Este verbo está disponível com os parâmetros Authorization e code.",
+							"minimalVersion": "12.1.23"
+						}
+					]
+				},
+				"parameters": [
+					{
+						"$ref": "https://raw.githubusercontent.com/totvs/ttalk-standard-message/master/jsonschema/apis/types/totvsApiTypesBase.json#/parameters/Authorization"
+					},
+					{
+						"$ref": "#/components/parameters/code"
+					},
+					{
+						"$ref": "https://raw.githubusercontent.com/totvs/ttalk-standard-message/master/jsonschema/apis/types/totvsApiTypesBase.json#/parameters/Order"
+					},
+					{
+						"$ref": "https://raw.githubusercontent.com/totvs/ttalk-standard-message/master/jsonschema/apis/types/totvsApiTypesBase.json#/parameters/Fields"
+					},
+					{
+						"$ref": "https://raw.githubusercontent.com/totvs/ttalk-standard-message/master/jsonschema/apis/types/totvsApiTypesBase.json#/parameters/Page"
+					},
+					{
+						"$ref": "https://raw.githubusercontent.com/totvs/ttalk-standard-message/master/jsonschema/apis/types/totvsApiTypesBase.json#/parameters/PageSize"
+					}
+				],
+				"responses": {
+					"200": {
+						"description": "Operação realizada com sucesso!",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "https://raw.githubusercontent.com/totvs/ttalk-standard-message/RetailPriceList/v1/2_006/jsonschema/schemas/PriceListHeaderItem_2_006.json#/definitions/PagedItensTablePrice"
+								}
+							}
+						}
+					},
+					"404": {
+						"description": "Registro não encontrado!",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "https://raw.githubusercontent.com/totvs/ttalk-standard-message/master/jsonschema/apis/types/totvsApiTypesBase.json#/definitions/ErrorModel"
+								}
+							}
+						}
+					}
+				},
+				"security": [
+					{
+						"api_key": []
+					}
+				]
+			},
+			"post": {
+				"tags": [
+					"itensTablePrice"
+				],
+				"summary": "Inclui um item na Tabela de Preço",
+				"description": "Inclui um novo item na tabela de preço conforme dados enviados.",
+				"operationId": "postpriceListItems",
+				"x-totvs": {
+					"productInformation": [
+						{
+							"product": "Protheus",
+							"available": false,
+							"note": "Este verbo está disponível com os parâmetros Authorization e code.",
+							"minimalVersion": "12.1.23"
+						}
+					]
+				},
+				"parameters": [
+					{
+						"$ref": "https://raw.githubusercontent.com/totvs/ttalk-standard-message/master/jsonschema/apis/types/totvsApiTypesBase.json#/parameters/Authorization"
+					},
+					{
+						"$ref": "#/components/parameters/code"
+					}
+				],
+				"requestBody": {
+					"description": "Tabela de preço a ser incluída.",
+					"content": {
+						"application/json": {
+							"schema": {
+								"$ref": "https://raw.githubusercontent.com/totvs/ttalk-standard-message/RetailPriceList/v1/2_006/jsonschema/schemas/PriceListHeaderItem_2_006.json#/definitions/itensTablePrices"
+							}
+						}
+					}
+				},
+				"responses": {
+					"201": {
+						"description": "Operação realizada com sucesso!",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "https://raw.githubusercontent.com/totvs/ttalk-standard-message/RetailPriceList/v1/2_006/jsonschema/schemas/PriceListHeaderItem_2_006.json#/definitions/PagedItensTablePrice"
+								}
+							}
+						}
+					},
+					"400": {
+						"description": "Erro durante inclusão da tabela de preço!",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "https://raw.githubusercontent.com/totvs/ttalk-standard-message/master/jsonschema/apis/types/totvsApiTypesBase.json#/definitions/ErrorModel"
+								}
+							}
+						}
+					}
+				},
+				"security": [
+					{
+						"api_key": []
+					}
+				]
+			}
+		},
+		"/retailPriceList/{InternalId}/itensTablePrice/{itemList}": {
+			"get": {
+				"tags": [
+					"itemTablePriceInternalId"
+				],
+				"summary": "Retorna um item específico de preço de acordo com o seu código",
+				"operationId": "getpriceListItemListInternalId",
+				"x-totvs": {
+					"productInformation": [
+						{
+							"product": "Protheus",
+							"available": false,
+							"note": "Este verbo está disponível com os parâmetros Authorization e code.",
+							"minimalVersion": "12.1.23"
+						}
+					]
+				},
+				"parameters": [
+					{
+						"$ref": "https://raw.githubusercontent.com/totvs/ttalk-standard-message/master/jsonschema/apis/types/totvsApiTypesBase.json#/parameters/Authorization"
+					},
+					{
+						"$ref": "#/components/parameters/code"
+					},
+					{
+						"$ref": "#/components/parameters/itemList"
+					},
+					{
+						"$ref": "https://raw.githubusercontent.com/totvs/ttalk-standard-message/master/jsonschema/apis/types/totvsApiTypesBase.json#/parameters/Order"
+					},
+					{
+						"$ref": "https://raw.githubusercontent.com/totvs/ttalk-standard-message/master/jsonschema/apis/types/totvsApiTypesBase.json#/parameters/Fields"
+					},
+					{
+						"$ref": "https://raw.githubusercontent.com/totvs/ttalk-standard-message/master/jsonschema/apis/types/totvsApiTypesBase.json#/parameters/Page"
+					},
+					{
+						"$ref": "https://raw.githubusercontent.com/totvs/ttalk-standard-message/master/jsonschema/apis/types/totvsApiTypesBase.json#/parameters/PageSize"
+					},
+					{
+						"$ref": "#/components/parameters/InternalId"
+					}
+				],
+				"responses": {
+					"200": {
+						"description": "Operação realizada com sucesso!",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "https://raw.githubusercontent.com/totvs/ttalk-standard-message/RetailPriceList/v1/2_006/jsonschema/schemas/PriceListHeaderItem_2_006.json#/definitions/PagedItensTablePrice"
+								}
+							}
+						}
+					},
+					"404": {
+						"description": "Registro não encontrado!",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "https://raw.githubusercontent.com/totvs/ttalk-standard-message/master/jsonschema/apis/types/totvsApiTypesBase.json#/definitions/ErrorModel"
+								}
+							}
+						}
+					}
+				},
+				"security": [
+					{
+						"api_key": []
+					}
+				]
+			}
+		},
+		"/retailPriceList/{code}/itensTablePrice/{itemList}": {
+			"get": {
+				"tags": [
+					"itemTablePrice"
+				],
+				"summary": "Retorna um item específico de preço de acordo com o seu código",
+				"operationId": "getpriceListItemList",
+				"x-totvs": {
+					"productInformation": [
+						{
+							"product": "Protheus",
+							"available": false,
+							"note": "Este verbo está disponível com os parâmetros Authorization e code.",
+							"minimalVersion": "12.1.23"
+						}
+					]
+				},
+				"parameters": [
+					{
+						"$ref": "https://raw.githubusercontent.com/totvs/ttalk-standard-message/master/jsonschema/apis/types/totvsApiTypesBase.json#/parameters/Authorization"
+					},
+					{
+						"$ref": "#/components/parameters/code"
+					},
+					{
+						"$ref": "#/components/parameters/itemList"
+					},
+					{
+						"$ref": "https://raw.githubusercontent.com/totvs/ttalk-standard-message/master/jsonschema/apis/types/totvsApiTypesBase.json#/parameters/Order"
+					},
+					{
+						"$ref": "https://raw.githubusercontent.com/totvs/ttalk-standard-message/master/jsonschema/apis/types/totvsApiTypesBase.json#/parameters/Fields"
+					},
+					{
+						"$ref": "https://raw.githubusercontent.com/totvs/ttalk-standard-message/master/jsonschema/apis/types/totvsApiTypesBase.json#/parameters/Page"
+					},
+					{
+						"$ref": "https://raw.githubusercontent.com/totvs/ttalk-standard-message/master/jsonschema/apis/types/totvsApiTypesBase.json#/parameters/PageSize"
+					}
+				],
+				"responses": {
+					"200": {
+						"description": "Operação realizada com sucesso!",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "https://raw.githubusercontent.com/totvs/ttalk-standard-message/RetailPriceList/v1/2_006/jsonschema/schemas/PriceListHeaderItem_2_006.json#/definitions/PagedItensTablePrice"
+								}
+							}
+						}
+					},
+					"404": {
+						"description": "Registro não encontrado!",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "https://raw.githubusercontent.com/totvs/ttalk-standard-message/master/jsonschema/apis/types/totvsApiTypesBase.json#/definitions/ErrorModel"
+								}
+							}
+						}
+					}
+				},
+				"security": [
+					{
+						"api_key": []
+					}
+				]
+			},
+			"put": {
+				"tags": [
+					"itemTablePrice"
+				],
+				"summary": "Altera um item da tabela de preço",
+				"description": "Atualiza um item da tabela de preço conforme dados enviados na requisição",
+				"operationId": "putpriceListItemList",
+				"x-totvs": {
+					"productInformation": [
+						{
+							"product": "Protheus",
+							"available": false,
+							"note": "Este verbo está disponível com os parâmetros Authorization e code.",
+							"minimalVersion": "12.1.23"
+						}
+					]
+				},
+				"parameters": [
+					{
+						"$ref": "https://raw.githubusercontent.com/totvs/ttalk-standard-message/master/jsonschema/apis/types/totvsApiTypesBase.json#/parameters/Authorization"
+					},
+					{
+						"$ref": "#/components/parameters/code"
+					},
+					{
+						"$ref": "#/components/parameters/itemList"
+					},
+					{
+						"$ref": "https://raw.githubusercontent.com/totvs/ttalk-standard-message/master/jsonschema/apis/types/totvsApiTypesBase.json#/parameters/Fields"
+					}
+				],
+				"requestBody": {
+					"description": "Tabela de preço a ser atualizada.",
+					"content": {
+						"application/json": {
+							"schema": {
+								"$ref": "https://raw.githubusercontent.com/totvs/ttalk-standard-message/RetailPriceList/v1/2_006/jsonschema/schemas/PriceListHeaderItem_2_006.json#/definitions/itensTablePrices"
+							}
+						}
+					}
+				},
+				"responses": {
+					"200": {
+						"description": "Operação realizada com sucesso!",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "https://raw.githubusercontent.com/totvs/ttalk-standard-message/RetailPriceList/v1/2_006/jsonschema/schemas/PriceListHeaderItem_2_006.json#/definitions/PagedItensTablePrice"
+								}
+							}
+						}
+					},
+					"400": {
+						"description": "Erro ao alterar a tabela de preço!",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "https://raw.githubusercontent.com/totvs/ttalk-standard-message/master/jsonschema/apis/types/totvsApiTypesBase.json#/definitions/ErrorModel"
+								}
+							}
+						}
+					},
+					"404": {
+						"description": "Registro não encontrado!",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "https://raw.githubusercontent.com/totvs/ttalk-standard-message/master/jsonschema/apis/types/totvsApiTypesBase.json#/definitions/ErrorModel"
+								}
+							}
+						}
+					}
+				},
+				"security": [
+					{
+						"api_key": []
+					}
+				]
+			},
+			"delete": {
+				"tags": [
+					"itemTablePrice"
+				],
+				"summary": "Exclui um item da tabela de preço",
+				"description": "Exclui um item da tabela de preço conforme dados enviados na requisição.",
+				"operationId": "deletepriceListItemList",
+				"x-totvs": {
+					"productInformation": [
+						{
+							"product": "Protheus",
+							"available": false,
+							"note": "Este verbo está disponível com os parâmetros Authorization e code.",
+							"minimalVersion": "12.1.23"
+						}
+					]
+				},
+				"parameters": [
+					{
+						"$ref": "https://raw.githubusercontent.com/totvs/ttalk-standard-message/master/jsonschema/apis/types/totvsApiTypesBase.json#/parameters/Authorization"
+					},
+					{
+						"$ref": "#/components/parameters/code"
+					},
+					{
+						"$ref": "#/components/parameters/itemList"
+					}
+				],
+				"responses": {
+					"200": {
+						"description": "Operação realizada com sucesso!",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "https://raw.githubusercontent.com/totvs/ttalk-standard-message/RetailPriceList/v1/2_006/jsonschema/schemas/PriceListHeaderItem_2_006.json#/definitions/PagedPriceListHeaderItems"
+								}
+							}
+						}
+					},
+					"400": {
+						"description": "Erro durante a exclusão da tabela de preço! ",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "https://raw.githubusercontent.com/totvs/ttalk-standard-message/master/jsonschema/apis/types/totvsApiTypesBase.json#/definitions/ErrorModel"
+								}
+							}
+						}
+					},
+					"404": {
+						"description": "Registro não encontrado!",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "https://raw.githubusercontent.com/totvs/ttalk-standard-message/master/jsonschema/apis/types/totvsApiTypesBase.json#/definitions/ErrorModel"
+								}
+							}
+						}
+					}
+				},
+				"security": [
+					{
+						"api_key": []
+					}
+				]
+			}
+		}
+	},
+	"components": {
+		"parameters": {
+			"code": {
+				"name": "code",
+				"in": "path",
+				"required": true,
+				"description": "Identificador único da tabela de preço",
+				"schema": {
+					"type": "string"
+				}
+			},
+			"InternalId": {
+				"name": "InternalId",
+				"in": "path",
+				"required": true,
+				"description": "Identificador único da tabela de preço",
+				"schema": {
+					"type": "string"
+				}
+			},
+			"itemList": {
+				"name": "itemList",
+				"in": "path",
+				"required": true,
+				"description": "Identificador do item da tabela de preço",
+				"schema": {
+					"$ref": "https://raw.githubusercontent.com/totvs/ttalk-standard-message/RetailPriceList/v1/2_006/jsonschema/schemas/PriceListHeaderItem_2_006.json#/definitions/itensTablePriceInfo"
+				}
+			}
+		},
+		"schemas": {}
+	}
+}

--- a/jsonschema/apis/RetailPriceList_v1_000.json
+++ b/jsonschema/apis/RetailPriceList_v1_000.json
@@ -31,7 +31,7 @@
       },
       "productInformation": [
         {
-          "product": "Protheus",
+          "product": "protheus",
           "contact": "rafael.tenorio@totvs.com.br",
           "description": "Consulta de Preços - Varejo",
           "adapter": "",
@@ -50,7 +50,7 @@
         "x-totvs": {
           "productInformation": [
             {
-              "product": "Protheus",
+              "product": "protheus",
               "available": true,
               "note": "Este verbo esta disponível com todos os parâmetros.",
               "minimalVersion": "12.1.23"
@@ -115,7 +115,7 @@
         "x-totvs": {
           "productInformation": [
             {
-              "product": "Protheus",
+              "product": "protheus",
               "available": true,
               "note": "Este verbo está disponível com os parâmetros Authorization, Order, Fields e InternalId.",
               "minimalVersion": "12.1.23"
@@ -175,7 +175,7 @@
         "x-totvs": {
           "productInformation": [
             {
-              "product": "Protheus",
+              "product": "protheus",
               "available": true,
               "note": "Este verbo esta disponível com todos os parâmetros.",
               "minimalVersion": "12.1.23"

--- a/jsonschema/schemas/PriceListHeaderItem_2_006.json
+++ b/jsonschema/schemas/PriceListHeaderItem_2_006.json
@@ -1,0 +1,1027 @@
+{
+	"$schema": "https://raw.githubusercontent.com/totvs/ttalk-standard-message/RetailPriceList/v1/2_006/jsonschema/schemas/PriceListHeaderItem_2_006.json#",
+	"info": {
+		"description": "",
+		"version": "2.006",
+		"title": "priceListHeaderItem",
+		"contact": {},
+		"x-totvs": {
+			"transactionDefinition": {
+				"subType": "event",
+				"businessContentType": {
+					"type": "object",
+					"$ref": "#/definitions/PriceListHeaderItemsInfo"
+				},
+				"returnContentType": {
+					"type": "object",
+					"$ref": "https://raw.githubusercontent.com/totvs/ttalk-standard-message/master/jsonschema/schemas/types/ListOfInternalId_1_000.json#/definitions/ReturnContentWithModelType"
+				}
+			},
+			"messageDocumentation": {
+				"name": "Tabela de Preços",
+				"description": "Cadastro de Tabela de Preços para produtos Totvs",
+				"segment": "Manufatura"
+			},
+			"productInformation": [
+				{
+					"product": "DATASUL",
+					"contact": "supply.ml.man.sup.comex.d@totvs.com.br@totvs.com.br",
+					"description": "Cadastro de Tabela de Preços",
+					"adapter": ""
+				},
+				{
+					"product": "protheus",
+					"contact": "squad.crm@totvs.com.br",
+					"description": "Cadastro de Tabela de Preço",
+					"adapter": "omsa010.prx"
+				}
+			]
+		}
+	},
+	"definitions": {
+		"PagedPriceListHeader": {
+			"type": "object",
+			"allOf": [
+				{
+					"$ref": "https://raw.githubusercontent.com/totvs/ttalk-standard-message/master/jsonschema/apis/types/totvsApiTypesBase.json#/definitions/Paging"
+				},
+				{
+					"type": "object",
+					"properties": {
+						"items": {
+							"type": "array",
+							"items": {
+								"$ref": "#/definitions/PriceListHeaderInfo"
+							}
+						}
+					}
+				}
+			]
+		},
+		"PriceListHeaderInfo": {
+			"type": "object",
+			"properties": {
+				"branchId": {
+					"type": "string",
+					"description": "ID Filial",
+					"x-totvs": [
+						{
+							"product": "protheus",
+							"required": false,
+							"type": "Char",
+							"length": "2",
+							"description": "Pode ter tamanho variável até 8 com Gestão de Empresa ativado",
+							"available": true
+						},
+						{
+							"product": "datasul",
+							"required": false,
+							"available": false
+						}
+					]
+				},
+				"companyInternalId": {
+					"type": "string",
+					"description": "InternalId da chave completa de empresa do produto",
+					"x-totvs": [
+						{
+							"product": "protheus",
+							"note": "para o Protheus é esperado que com o cabeçalho da mensagem seja identificado empresa e filial já pelo Framework estando no ambiente (Empresa x Filial) correto",
+							"available": true
+						},
+						{
+							"product": "datasul",
+							"required": false,
+							"available": false
+						}
+					]
+				},
+				"identifyPriceList": {
+					"type": "string",
+					"description": "Identificador da Tabela de Preços recebida na mensagem.",
+					"x-totvs": [
+						{
+							"product": "datasul",
+							"field": "",
+							"required": true,
+							"type": "varchar",
+							"length": "7",
+							"available": true,
+							"note": "Para tabela de Preços do módulo de Compras, deverá ser enviada a informação 'Compras'"
+						}
+					]
+				},
+				"code": {
+					"type": "string",
+					"description": "Código da tabela de preço",
+					"maxLength": 4,
+					"x-totvs": [
+						{
+							"product": "protheus",
+							"field": "DA0.DA0_CODTAB",
+							"required": true,
+							"type": "varchar",
+							"length": "6",
+							"available": true
+						},
+						{
+							"product": "datasul",
+							"field": "tb-pr-cc.nr-tab",
+							"required": true,
+							"type": "varchar",
+							"length": "10",
+							"available": true,
+							"note": "Utilizado quando Identificador for 'Compras'",
+							"canUpdate": false
+						}
+					]
+				},
+				"internalId": {
+					"type": "string",
+					"description": "InternalId da chave completa da tabela de preço",
+					"x-totvs": [
+						{
+							"product": "protheus",
+							"note": "InternalID da tabela de preço utilizado na integração EAI-TOTVS formado por EMPRESA|DA0_FILIAL|DA0_CODTAB",
+							"available": true
+						},
+						{
+							"product": "datasul",
+							"required": false,
+							"available": false
+						}
+					]
+				},
+				"companyId": {
+					"type": "string",
+					"description": "Código da empresa",
+					"x-totvs": [
+						{
+							"product": "protheus",
+							"required": false,
+							"type": "varchar",
+							"length": "4",
+							"note": "pode ter tamanho variável até 4 com Gestão de Empresa ativado",
+							"available": true
+						},
+						{
+							"product": "datasul",
+							"required": false,
+							"available": false
+						}
+					]
+				},
+				"name": {
+					"type": "string",
+					"description": "Descrição da Tabela",
+					"maxLength": 40,
+					"x-totvs": [
+						{
+							"product": "protheus",
+							"field": "DA0.DA0_DESCRI",
+							"note": "Descrição",
+							"length": "30",
+							"available": true
+						},
+						{
+							"product": "datasul",
+							"field": "tb-pr-cc.descricao",
+							"required": true,
+							"type": "varchar",
+							"length": "40",
+							"available": true,
+							"note": "Utilizado quando Identificador for 'Compras'",
+							"canUpdate": true
+						}
+					]
+				},
+				"provider": {
+					"type": "string",
+					"description": "Fornecedor da Tabela de Preços",
+					"x-totvs": [
+						{
+							"product": "datasul",
+							"field": "tb-pr-cc.cod-emitente",
+							"required": true,
+							"type": "varchar",
+							"length": "9",
+							"available": true,
+							"note": "Utilizado quando Identificador for 'Compras'",
+							"canUpdate": false
+						}
+					]
+				},
+				"paymentTerms": {
+					"type": "string",
+					"description": "Condição de Pagamento da Tabela de Preço",
+					"x-totvs": [
+						{
+							"product": "datasul",
+							"field": "tb-pr-cc.cod-cond-pag",
+							"required": true,
+							"type": "varchar",
+							"length": "4",
+							"available": true,
+							"note": "Utilizado quando Identificador for 'Compras'",
+							"canUpdate": false
+						}
+					]
+				},
+				"company": {
+					"type": "string",
+					"description": "Estabelecimento da Tabela de Preço",
+					"x-totvs": [
+						{
+							"product": "datasul",
+							"field": "tb-pr-cc.cod-estabel",
+							"required": true,
+							"type": "varchar",
+							"length": "5",
+							"available": true,
+							"note": "Utilizado quando Identificador for 'Compras'",
+							"canUpdate": false
+						}
+					]
+				},
+				"initialDate": {
+					"type": "string",
+					"format": "date",
+					"example": "2018-07-19",
+					"description": "Data Inicial da Vigência AAAA-MM-DD",
+					"maxLength": 10,
+					"x-totvs": [
+						{
+							"product": "protheus",
+							"field": "DA0.DA0_DATDE",
+							"required": true,
+							"type": "varchar",
+							"length": 10,
+							"description": "o conteúdo deve vir DD/MM/AAAA",
+							"available": true
+						},
+						{
+							"product": "datasul",
+							"field": "tb-pr-cc.dt-inicio",
+							"required": true,
+							"type": "varchar",
+							"length": 10,
+							"description": "o conteúdo deve vir DD/MM/AAAA",
+							"note": "Utilizado quando Identificador for 'Compras'",
+							"canUpdate": true,
+							"available": true
+						}
+					]
+				},
+				"finalDate": {
+					"type": "string",
+					"format": "date",
+					"example": "20180719",
+					"description": "Data Final da Vigência AAAAMMDD",
+					"x-totvs": [
+						{
+							"product": "protheus",
+							"field": "DA0.DA0_DATATE",
+							"description": "o conteúdo deve vir DD/MM/AAAA",
+							"required": true,
+							"type": "varchar",
+							"length": 10,
+							"available": true
+						},
+						{
+							"product": "datasul",
+							"field": "tb-pr-cc.dt-termino",
+							"required": true,
+							"type": "varchar",
+							"length": 10,
+							"description": "o conteúdo deve vir DD/MM/AAAA",
+							"note": "Utilizado quando Identificador for 'Compras'",
+							"canUpdate": true,
+							"available": true
+						}
+					]
+				},
+				"initiaHour": {
+					"type": "string",
+					"format": "date-time",
+					"description": "Hora Inicial Vigencia HH:MM:SS",
+					"x-totvs": [
+						{
+							"product": "protheus",
+							"field": "DA0.DA0_HORADE",
+							"description": "Hora inicial de vigência da tabela de preço. No protheus o formato deverá ser HH:MM",
+							"required": true,
+							"type": "varchar",
+							"length": 5,
+							"available": true
+						},
+						{
+							"product": "datasul",
+							"required": false,
+							"available": false
+						}
+					]
+				},
+				"finalHour": {
+					"type": "string",
+					"format": "date-time",
+					"description": "Hora Final Vigencia HH:MM:SS",
+					"x-totvs": [
+						{
+							"product": "protheus",
+							"field": "DA0.DA0_HORATE",
+							"description": "Hora final de vigência da tabela de preço. No protheus o formato deverá ser HH:MM",
+							"required": true,
+							"type": "varchar",
+							"length": 5,
+							"available": true
+						},
+						{
+							"product": "datasul",
+							"required": false,
+							"available": false
+						}
+					]
+				},
+				"currency": {
+					"type": "string",
+					"description": "Moeda da Tabela de Preço",
+					"x-totvs": [
+						{
+							"product": "datasul",
+							"field": "tb-pr-cc.mo-codigo",
+							"required": true,
+							"type": "varchar",
+							"length": "2",
+							"available": true,
+							"note": "Utilizado quando Identificador for 'Compras'",
+							"canUpdate": false
+						}
+					]
+				},
+				"IncludedIPI": {
+					"type": "string",
+					"description": "IPI Incluso? 1 = Sim; 2 = Não",
+					"enum": [
+						"1",
+						"2"
+					],
+					"x-totvs": [
+						{
+							"product": "datasul",
+							"field": "tb-pr-cc.codigo-ipi",
+							"required": true,
+							"type": "varchar",
+							"length": 1,
+							"description": "Determina se o percentual de IPI está incluso no preço do item pertencente à tabela",
+							"note": "Utilizado quando Identificador for 'Compras'",
+							"canUpdate": true,
+							"available": true
+						}
+					]
+				},
+				"valueDescount": {
+					"type": "number",
+					"format": "double",
+					"description": "Desconto Tabela de Preço",
+					"maxLength": 12
+				},
+				"discountFactor": {
+					"type": "number",
+					"format": "double",
+					"description": "Percentual de Desconto",
+					"maxLength": 5,
+					"x-totvs": [
+						{
+							"product": "datasul",
+							"field": "tb-pr-cc.perc-descto",
+							"required": true,
+							"type": "varchar",
+							"length": 5,
+							"description": "Percentual de desconto a ser incluso ao item da Tabela de Preço",
+							"note": "Utilizado quando Identificador for 'Compras'. Campo com duas casas decimais.",
+							"canUpdate": true,
+							"available": true
+						}
+					]
+				},
+				"activeTablePrice": {
+					"type": "string",
+					"description": "Tabela de Preco Ativo? 1 = Sim; 2 = Não",
+					"enum": [
+						"1",
+						"2"
+					],
+					"x-totvs": [
+						{
+							"product": "protheus",
+							"field": "DA0.DA0_ATIVO",
+							"decription": "Tabela Ativa",
+							"type": "varchar",
+							"length": "1",
+							"available": true
+						},
+						{
+							"product": "datasul",
+							"field": "tb-pr-cc.situacao",
+							"required": true,
+							"type": "varchar",
+							"length": 1,
+							"description": "Tabela Ativa/Inativa",
+							"note": "Utilizado quando Identificador for 'Compras'",
+							"canUpdate": true,
+							"available": true
+						}
+					]
+				},
+				"freightValue": {
+					"type": "number",
+					"format": "double",
+					"description": "Valor do Frete",
+					"maxLength": 14,
+					"x-totvs": [
+						{
+							"product": "datasul",
+							"field": "tb-pr-cc.valor-frete",
+							"length": "12",
+							"description": "Valor do Frete",
+							"note": "Utilizado quando Identificador for 'Compras'. Campo com quatro casas decimais.",
+							"canUpdate": true,
+							"available": true
+						}
+					]
+				},
+				"IncludedFreight": {
+					"type": "string",
+					"description": "Frete Incluso? 1 = Sim; 2 = Não",
+					"enum": [
+						"1",
+						"2"
+					],
+					"x-totvs": [
+						{
+							"product": "datasul",
+							"field": "tb-pr-cc.frete",
+							"required": true,
+							"type": "varchar",
+							"length": 1,
+							"description": "Determina que o valor do frete está incluso no preço do item pertencente à tabela",
+							"note": "Utilizado quando Identificador for 'Compras'",
+							"canUpdate": true,
+							"available": true
+						}
+					]
+				},
+				"aliquotICMS": {
+					"type": "number",
+					"format": "double",
+					"description": "Alíquota do ICMS",
+					"maxLength": 6,
+					"x-totvs": [
+						{
+							"product": "datasul",
+							"field": "tb-pr-cc.aliquota-icm",
+							"length": "6",
+							"description": "Alíquota do ICMS",
+							"note": "Utilizado quando Identificador for 'Compras'. Campo com duas casas decimais",
+							"canUpdate": true,
+							"available": true
+						}
+					]
+				},
+				"note": {
+					"type": "string",
+					"description": "Observação da Tabela de Preço",
+					"maxLength": 2000,
+					"x-totvs": [
+						{
+							"product": "datasul",
+							"field": "tb-pr-cc.observacao",
+							"length": "2000",
+							"description": "Observação da Tabela de Preço",
+							"note": "Utilizado quando Identificador for 'Compras'.",
+							"canUpdate": true,
+							"available": true
+						}
+					]
+				}
+			}
+		},
+		"PagedPriceListHeaderItems": {
+			"type": "object",
+			"allOf": [
+				{
+					"$ref": "https://raw.githubusercontent.com/totvs/ttalk-standard-message/master/jsonschema/apis/types/totvsApiTypesBase.json#/definitions/Paging"
+				},
+				{
+					"type": "object",
+					"properties": {
+						"items": {
+							"type": "array",
+							"items": {
+								"$ref": "#/definitions/PriceListHeaderItemsInfo"
+							}
+						}
+					}
+				}
+			]
+		},
+		"PriceListHeaderItemsInfo": {
+			"type": "object",
+			"properties": {
+				"PriceListHeaderInfo": {
+					"type": "object",
+					"$ref": "#/definitions/PriceListHeaderInfo"
+				},
+				"itensTablePrice": {
+					"type": "object",
+					"$ref": "#/definitions/itensTablePriceInfo"
+				}
+			}
+		},
+		"PagedItensTablePrice": {
+			"type": "object",
+			"allOf": [
+				{
+					"$ref": "https://raw.githubusercontent.com/totvs/ttalk-standard-message/master/jsonschema/apis/types/totvsApiTypesBase.json#/definitions/Paging"
+				},
+				{
+					"$ref": "#/definitions/itensTablePrices"
+				}
+			]
+		},
+		"itensTablePrices": {
+			"description": "será necessário alterar o nome deste elemento na próxima versão. Sugestão: 'ListOfTablePrice'",
+			"type": "object",
+			"properties": {
+				"items": {
+					"$ref": "#/definitions/itensTablePriceInfo"
+				}
+			}
+		},
+		"itensTablePriceInfo": {
+			"type": "array",
+			"items": {
+				"properties": {
+					"identifyPriceListItems": {
+						"type": "string",
+						"description": "Identificador da Tabela de Preços recebida na mensagem.",
+						"x-totvs": [
+							{
+								"product": "datasul",
+								"field": "",
+								"required": true,
+								"type": "varchar",
+								"length": "7",
+								"available": true,
+								"note": "Para tabela de Preços do módulo de Compras, deverá ser enviada a informação 'Compras'"
+							}
+						]
+					},
+					"provider": {
+						"type": "string",
+						"description": "Fornecedor da Tabela de Preços",
+						"x-totvs": [
+							{
+								"product": "datasul",
+								"field": "item-tab.cod-emitente",
+								"required": true,
+								"type": "varchar",
+								"length": "9",
+								"available": true,
+								"note": "Utilizado quando Identificador for 'Compras'",
+								"canUpdate": false
+							}
+						]
+					},
+					"code": {
+						"type": "string",
+						"description": "Código da Tabela de Preço",
+						"x-totvs": [
+							{
+								"product": "protheus",
+								"field": "DA1.DA1_CODTAB",
+								"required": true,
+								"type": "varchar",
+								"length": "6",
+								"available": true
+							},
+							{
+								"product": "datasul",
+								"field": "item-tab.nr-tab",
+								"required": true,
+								"type": "varchar",
+								"length": "10",
+								"available": true,
+								"note": "Utilizado quando Identificador for 'Compras'",
+								"canUpdate": false
+							}
+						]
+					},
+					"paymentTerms": {
+						"type": "string",
+						"description": "Condição de Pagamento da Tabela de Preço",
+						"x-totvs": [
+							{
+								"product": "datasul",
+								"field": "item-tab.cod-cond-pag",
+								"required": true,
+								"type": "varchar",
+								"length": "4",
+								"available": true,
+								"note": "Utilizado quando Identificador for 'Compras'",
+								"canUpdate": false
+							}
+						]
+					},
+					"company": {
+						"type": "string",
+						"description": "Estabelecimento da Tabela de Preço",
+						"x-totvs": [
+							{
+								"product": "datasul",
+								"field": "item-tab.cod-estabel",
+								"required": true,
+								"type": "varchar",
+								"length": "5",
+								"available": true,
+								"note": "Utilizado quando Identificador for 'Compras'",
+								"canUpdate": false
+							}
+						]
+					},
+					"currency": {
+						"type": "string",
+						"description": "Moeda da Tabela de Preço",
+						"x-totvs": [
+							{
+								"product": "datasul",
+								"field": "item-tab.mo-codigo",
+								"required": true,
+								"type": "varchar",
+								"length": "2",
+								"available": true,
+								"note": "Utilizado quando Identificador for 'Compras'",
+								"canUpdate": false
+							}
+						]
+					},
+					"itemList": {
+						"type": "string",
+						"description": "Item da Tabela",
+						"maxLength": 4,
+						"x-totvs": [
+							{
+								"product": "protheus",
+								"type": "varchar",
+								"field": "DA1.DA1_ITEM",
+								"description": "Item da Tabela de Preço",
+								"length": "4",
+								"available": true
+							},
+							{
+								"product": "datasul",
+								"required": false,
+								"available": false
+							}
+						]
+					},
+					"itemCode": {
+						"type": "string",
+						"description": "Código do Produto",
+						"maxLength": 30,
+						"x-totvs": [
+							{
+								"product": "protheus",
+								"type": "varchar",
+								"field": "DA1.DA1_CODPRO",
+								"description": "",
+								"length": "15",
+								"available": true
+							},
+							{
+								"product": "datasul",
+								"type": "varchar",
+								"field": "item-tab.it-codigo",
+								"description": "",
+								"length": "16",
+								"note": "Utilizado quando Identificador for 'Compras'",
+								"canUpdate": false,
+								"available": true
+							}
+						]
+					},
+					"itemInternalId": {
+						"type": "string",
+						"description": "InternalId da chave completa do Item",
+						"x-totvs": [
+							{
+								"product": "protheus",
+								"required": true,
+								"type": "varchar",
+								"length": "50",
+								"note": "InternalID do produto formado por EMPRESA|DA1_FILIAL|DA1_CODPRO|DA1_CODTAB|DA1_ITEM",
+								"available": true
+							},
+							{
+								"product": "datasul",
+								"required": false,
+								"available": false
+							}
+						]
+					},
+					"referenceCode": {
+						"type": "string",
+						"description": "Código da Referência do Produto",
+						"maxLength": 8,
+						"x-totvs": [
+							{
+								"product": "datasul",
+								"field": "cod-refer",
+								"required": true,
+								"type": "string",
+								"length": "8",
+								"note": "Utilizado quando não receber informação no Identificador",
+								"available": true
+							}
+						]
+					},
+					"unitOfMeasureCode": {
+						"type": "string",
+						"description": "Código da Unidade de Medida de Venda",
+						"maxLength": 2,
+						"x-totvs": [
+							{
+								"product": "datasul",
+								"field": "cod-unid-med",
+								"required": true,
+								"type": "string",
+								"length": "2",
+								"note": "Utilizado quando não receber informação no Identificador",
+								"available": true
+							}
+						]
+					},
+					"minimumSalesPrice": {
+						"type": "number",
+						"format": "double",
+						"description": "Preco mínimo de venda do produto - Valor Sem Frete",
+						"maxLength": 12,
+						"x-totvs": [
+							{
+								"product": "protheus",
+								"field": "DA1.DA1_PRCVEN",
+								"length": "12",
+								"description": "Preco Venda",
+								"note": "Campo com duas casas decimais",
+								"available": true
+							},
+							{
+								"product": "datasul",
+								"required": false,
+								"available": false
+							}
+						]
+					},
+					"itemPrice": {
+						"type": "number",
+						"format": "double",
+						"description": "Preco do Item",
+						"maxLength": 16,
+						"x-totvs": [
+							{
+								"product": "datasul",
+								"field": "item-tab.pr-item",
+								"length": "16",
+								"description": "Preco do Item",
+								"note": "Utilizado quando Identificador for 'Compras'. Campo com cinco casas decimais",
+								"canUpdate": true,
+								"available": true
+							}
+						]
+					},
+					"aliquotIPI": {
+						"type": "number",
+						"format": "double",
+						"description": "Alíquota do IPI",
+						"maxLength": 6,
+						"x-totvs": [
+							{
+								"product": "datasul",
+								"field": "item-tab.aliquota-ipi",
+								"length": "6",
+								"description": "Alíquota do IPI",
+								"note": "Utilizado quando Identificador for 'Compras'. Campo com duas casas decimais",
+								"canUpdate": true,
+								"available": true
+							}
+						]
+					},
+					"minimumSalesPriceFOB": {
+						"type": "number",
+						"format": "double",
+						"description": "Preco de minimo de venda do produto - FOB",
+						"maxLength": 12
+					},
+					"discountValue": {
+						"type": "number",
+						"format": "double",
+						"description": "Valor de Desconto em reais",
+						"maxLength": 12,
+						"x-totvs": [
+							{
+								"product": "protheus",
+								"field": "DA1.DA1_VLRDES",
+								"length": "9",
+								"description": "Vlr.Desconto",
+								"note": "Campo com duas casas decimais",
+								"available": true
+							},
+							{
+								"product": "datasul",
+								"required": false,
+								"available": false
+							}
+						]
+					},
+					"discountAmount": {
+						"type": "number",
+						"format": "double",
+						"description": "Desconto por quantidade",
+						"maxLength": 9,
+						"x-totvs": [
+							{
+								"product": "datasul",
+								"field": "item-tab.desco-quant",
+								"length": "9",
+								"description": "Desconto por Quantidade",
+								"note": "Utilizado quando Identificador for 'Compras'. Campo com cinco casas decimais",
+								"canUpdate": true,
+								"available": true
+							}
+						]
+					},
+					"discountFactor": {
+						"type": "number",
+						"format": "double",
+						"description": "Fator de Acresc./Desconto%",
+						"maxLength": 11,
+						"x-totvs": [
+							{
+								"product": "protheus",
+								"field": "DA1.DA1_PERDES",
+								"length": "6",
+								"description": "Fator",
+								"note": "Campo com quatro casas decimais",
+								"available": true
+							},
+							{
+								"product": "datasul",
+								"required": false,
+								"available": false
+							}
+						]
+					},
+					"minimumAmount": {
+						"type": "number",
+						"format": "double",
+						"description": "Quantidade Mínima",
+						"maxLength": 12,
+						"x-totvs": [
+							{
+								"product": "datasul",
+								"field": "item-tab.quant-min",
+								"length": "12",
+								"description": "Quantidade mínima",
+								"note": "Atualização realizada quando Identificador for 'Compras'. Campo com 4 casas decimais",
+								"available": true
+							}
+						]
+					},
+					"cifPrice": {
+						"type": "number",
+						"format": "double",
+						"description": "Preco CIF",
+						"maxLength": 11
+					},
+					"fobPrice": {
+						"type": "number",
+						"format": "double",
+						"description": "Preco FOB",
+						"maxLength": 11
+					},
+					"itemValidity": {
+						"type": "string",
+						"format": "date",
+						"example": "2018-07-19",
+						"description": "Data Vigência do item AAAA-MM-DD",
+						"maxLength": 10,
+						"x-totvs": [
+							{
+								"product": "protheus",
+								"field": "DA1_DATVIG",
+								"discription": "Vigencia do item",
+								"type": "varchar",
+								"required": true,
+								"length": 1,
+								"note": "conteúdo deve vir DD/MM/AAAA",
+								"available": true
+							},
+							{
+								"product": "datasul",
+								"required": false,
+								"available": false
+							}
+						]
+					},
+					"aliquotICMS": {
+						"type": "number",
+						"format": "double",
+						"description": "Alíquota do ICMS",
+						"maxLength": 6,
+						"x-totvs": [
+							{
+								"product": "datasul",
+								"field": "item-tab.aliquota-icm",
+								"length": "6",
+								"description": "Alíquota do ICMS",
+								"note": "Utilizado quando Identificador for 'Compras'. Campo com duas casas decimais",
+								"canUpdate": true,
+								"available": true
+							}
+						]
+					},
+					"correctionGroup": {
+						"type": "string",
+						"format": "double",
+						"description": "Grupo de Correções",
+						"maxLength": 3,
+						"x-totvs": [
+							{
+								"product": "datasul",
+								"field": "item-tab.int-1",
+								"required": true,
+								"type": "varchar",
+								"length": "3",
+								"available": true,
+								"note": "Utilizado quando Identificador for 'Compras'",
+								"canUpdate": true
+							}
+						]
+					},
+					"typePrice": {
+						"type": "string",
+						"description": "Tipo da Tabela de Preço: 1 = Preco Venda , 2 = Venda Consumidor, 3 = Atacado , 4 = Varejo, 5 = Promocao",
+						"maxLength": 1,
+						"enum": [
+							"1",
+							"2",
+							"3",
+							"4",
+							"5"
+						],
+						"x-totvs": [
+							{
+								"product": "protheus",
+								"field": "DA1.DA1_TIPPRE",
+								"description": "Tipo Preço",
+								"note": "Tipo da Tabela de Preço: Preco Venda, Venda Consumidor, Atacado , Varejo, Promoção",
+								"available": true
+							},
+							{
+								"product": "datasul",
+								"required": false,
+								"available": false
+							}
+						]
+					},
+					"activeItemPrice": {
+						"type": "string",
+						"description": "Status do Item da Tabela de Preço: 1 = Sim; 2 = Não",
+						"maxLength": 1,
+						"enum": [
+							"1",
+							"2"
+						],
+						"x-totvs": [
+							{
+								"product": "protheus",
+								"field": "DA1_ATIVO",
+								"discription": "Ativo",
+								"type": "varchar",
+								"required": false,
+								"length": 1,
+								"note": "1 = Sim; 2 = Não",
+								"available": true
+							},
+							{
+								"product": "datasul",
+								"required": false,
+								"available": false
+							}
+						]
+					}
+				}
+			}
+		}
+	}
+}

--- a/jsonschema/schemas/PriceListHeaderItem_2_006.json
+++ b/jsonschema/schemas/PriceListHeaderItem_2_006.json
@@ -148,7 +148,7 @@
 						},
 						{
 							"product": "datasul",
-							"required": false,
+							"required": true,
 							"available": false
 						}
 					]

--- a/jsonschema/schemas/PriceListHeaderItem_2_006.json
+++ b/jsonschema/schemas/PriceListHeaderItem_2_006.json
@@ -1,8 +1,8 @@
 {
-	"$schema": "https://raw.githubusercontent.com/totvs/ttalk-standard-message/RetailPriceList/v1/2_006/jsonschema/schemas/PriceListHeaderItem_2_006.json#",
+	"$schema": "https://raw.githubusercontent.com/totvs/ttalk-standard-message/master/jsonschema/schemas/PriceListHeaderItem_2_005.json#",
 	"info": {
 		"description": "",
-		"version": "2.006",
+		"version": "2.005",
 		"title": "priceListHeaderItem",
 		"contact": {},
 		"x-totvs": {
@@ -505,7 +505,7 @@
 					]
 				}
 			}
-		},
+		},	
 		"PagedPriceListHeaderItems": {
 			"type": "object",
 			"allOf": [
@@ -527,8 +527,8 @@
 		},
 		"PriceListHeaderItemsInfo": {
 			"type": "object",
-			"properties": {
-				"PriceListHeaderInfo": {
+			"properties": {				
+				"PriceListHeader": {
 					"type": "object",
 					"$ref": "#/definitions/PriceListHeaderInfo"
 				},

--- a/jsonschema/schemas/PriceListHeaderItem_2_006.json
+++ b/jsonschema/schemas/PriceListHeaderItem_2_006.json
@@ -618,6 +618,18 @@
 							}
 						]
 					},
+					"tableInternalId": {
+						"type": "string",
+						"description": "InternalId da chave completa da tabela de preço",
+						"x-totvs": [
+							{
+								"product": "protheus",
+								"note": "InternalID da tabela de preço utilizado na integração via API formado por DA0_FILIAL|DA0_CODTAB",
+								"required": true,
+								"available": true
+							}
+						]
+					},
 					"paymentTerms": {
 						"type": "string",
 						"description": "Condição de Pagamento da Tabela de Preço",

--- a/jsonschema/schemas/PriceListHeaderItem_2_006.json
+++ b/jsonschema/schemas/PriceListHeaderItem_2_006.json
@@ -143,6 +143,7 @@
 						{
 							"product": "protheus",
 							"note": "InternalID da tabela de preço utilizado na integração EAI-TOTVS formado por EMPRESA|DA0_FILIAL|DA0_CODTAB",
+							"required": true,
 							"available": true
 						},
 						{

--- a/jsonschema/schemas/PriceListHeaderItem_2_006.json
+++ b/jsonschema/schemas/PriceListHeaderItem_2_006.json
@@ -1,8 +1,8 @@
 {
-	"$schema": "https://raw.githubusercontent.com/totvs/ttalk-standard-message/master/jsonschema/schemas/PriceListHeaderItem_2_005.json#",
+	"$schema": "https://raw.githubusercontent.com/totvs/ttalk-standard-message/RetailPriceList/v1/2_006/jsonschema/schemas/PriceListHeaderItem_2_006.json#",
 	"info": {
 		"description": "",
-		"version": "2.005",
+		"version": "2.006",
 		"title": "priceListHeaderItem",
 		"contact": {},
 		"x-totvs": {
@@ -506,7 +506,7 @@
 					]
 				}
 			}
-		},	
+		},
 		"PagedPriceListHeaderItems": {
 			"type": "object",
 			"allOf": [
@@ -528,7 +528,7 @@
 		},
 		"PriceListHeaderItemsInfo": {
 			"type": "object",
-			"properties": {				
+			"properties": {
 				"PriceListHeader": {
 					"type": "object",
 					"$ref": "#/definitions/PriceListHeaderInfo"


### PR DESCRIPTION
Criação da API de Consulta de Preços do Varejo

Temos a necessidade de criar a API de lista de preço para o Varejo, conforme o Paulo já adiantou.

API RetailPriceList - Nova API do Varejo para Tabela de Preços (RetailPriceList_v1_000) para consultas
Atualizado schema (PriceListHeaderItem_2_006.json), porque precisamos incluir um novo "definitions" "PagedPriceListHeader", para retornar apenas o cabeçalho da Tabela de Preço sem os itens, em um GET especifico.