### PR TITLE
Atualização do Schema da API

### DIFF
--- a/jsonschema/schemas/CustomerCreditLimit_1_000.json
+++ b/jsonschema/schemas/CustomerCreditLimit_1_000.json
@@ -62,6 +62,11 @@
 			"description": "Descreve as Propriedades do Limite de credito do Cliente",
 			"type": "object",
 			"properties": {
+				"CompanyInternalId": {
+					"type": "string",
+					"example": "D ",
+					"description": "Código da Empresa"
+				},
 				"CustomerInternalId": {
 					"type": "string",
 					"example": "D MG    00000101",
@@ -106,6 +111,24 @@
 						}
 					]
 				},
+				"TotalCreditLimit": {
+					"description": "Total de limite de crédito concedido ao cliente",
+					"example": 6000.61,
+					"type": "number",
+					"minimum": 0,
+					"maximum": 999999999.99,
+					"x-totvs": [
+						{
+							"product": "protheus",
+							"field": "SA1.A1_LC",
+							"type": "number",
+							"length": "12",
+							"required": true,
+							"available": true,
+							"canUpdate": true
+						}
+					]
+				},
 				"CreditLimit": {
 					"description": "Limite de Credito do cliente",
 					"example": 5162.81,
@@ -123,7 +146,63 @@
 							"canUpdate": true
 						}
 					]
+				},
+				"CreditLimitUsedByBilling": {
+					"description": "Limite de crédito usado por faturamento",
+					"example": 7000.71,
+					"type": "number",
+					"minimum": 0,
+					"maximum": 999999999.99,
+					"x-totvs": [
+						{
+							"product": "protheus",
+							"field": "SA1.A1_SALDUP",
+							"type": "number",
+							"length": "12",
+							"required": true,
+							"available": true,
+							"canUpdate": true
+						}
+					]
+				},
+				"CreditLimitUsedBySalesOrders": {
+					"description": "Limite de crédito usado por pedidos de venda em aberto/liberados",
+					"example": 8000.81,
+					"type": "number",
+					"minimum": 0,
+					"maximum": 999999999.99,
+					"x-totvs": [
+						{
+							"product": "protheus",
+							"field": "SA1.A1_SALPED + SA1.A1_SALPEDL",
+							"type": "number",
+							"length": "12",
+							"required": true,
+							"available": true,
+							"canUpdate": true
+						}
+					]
+				},
+				"CreditLimitUsedByOrdersAndFinance": {
+					"description": "Limite de crédito usado por pedidos e financeiro",
+					"example": 9000.92,
+					"type": "number",
+					"minimum": 0,
+					"maximum": 999999999.99,
+					"x-totvs": [
+						{
+							"product": "protheus",
+							"field": "SA1.A1_LC - (SA1.A1_LC - SA1.A1_SALDUPM - SA1.A1_SALPEDL)",
+							"type": "number",
+							"length": "12",
+							"required": true,
+							"available": true,
+							"canUpdate": true
+						}
+					]
 				}
+
+				
 			}
 		}
 	}

--- a/jsonschema/schemas/SalesTaxes_1_000.json
+++ b/jsonschema/schemas/SalesTaxes_1_000.json
@@ -632,6 +632,20 @@
 							"minimum": 0,
 							"maximum": 999999999.99
 						},
+						"valor_pis_apur": {
+							"type": "number",
+							"description": "Valor do PIS/PASEP via apuração",
+							"example": 16.50,
+							"minimum": 0,
+							"maximum": 999999999.99
+						},
+						"valor_pis_st": {
+							"type": "number",
+							"description": "Valor do PIS/PASEP Subst. Tributaria",
+							"example": 16.50,
+							"minimum": 0,
+							"maximum": 999999999.99
+						},
 						"aliquota_cofins": {
 							"type": "number",
 							"description": "Alíquota do COFINS",
@@ -641,7 +655,21 @@
 						},
 						"valor_cofins": {
 							"type": "number",
-							"description": "Valor do COFINS",
+							"description": "Valor da COFINS",
+							"example": 76,
+							"minimum": 0,
+							"maximum": 999999999.99
+						},
+						"valor_cofins_apur": {
+							"type": "number",
+							"description": "Valor da COFINS via apuração",
+							"example": 76,
+							"minimum": 0,
+							"maximum": 999999999.99
+						},
+						"valor_cofins_st": {
+							"type": "number",
+							"description": "Valor da COFINS Subst. Tributaria",
 							"example": 76,
 							"minimum": 0,
 							"maximum": 999999999.99

--- a/jsonschema/schemas/SalesTaxes_1_000.json
+++ b/jsonschema/schemas/SalesTaxes_1_000.json
@@ -485,6 +485,13 @@
 		"ReturnSalesTaxes": {
 			"type": "object",
 			"properties": {
+				"valor_contabil": {
+					"description": "Total Contabil",
+					"example": 135000,
+					"type": "number",
+					"minimum": 0,
+					"maximum": 999999999.99
+				},
 				"valor_mercadoria": {
 					"description": "Valor Total de Mercadorias",
 					"example": 135000,
@@ -509,13 +516,6 @@
 				"total_impostos": {
 					"description": "Total de Tributos",
 					"example": 33783.76,
-					"type": "number",
-					"minimum": 0,
-					"maximum": 999999999.99
-				},
-				"valor_contabil": {
-					"description": "Total Contabil",
-					"example": 135000,
 					"type": "number",
 					"minimum": 0,
 					"maximum": 999999999.99
@@ -557,6 +557,197 @@
 							"example": "ICM"
 						}
 					}
+				},
+				"itens": {
+					"type": "object",
+					"description": "Detalhamento dos Tributos por Item do Documento Fiscal",
+					"properties": {
+						"valor_mercadoria": {
+							"type": "number",
+							"description": "Valor de Mercadoria do Item",
+							"example": 1000,
+							"minimum": 0,
+							"maximum": 999999999.99
+						},
+						"valor_st": {
+							"type": "number",
+							"description": "Valor do ICMS-ST",
+							"example": 100,
+							"minimum": 0,
+							"maximum": 999999999.99
+						},
+						"valor_total": {
+							"type": "number",
+							"description": "Valor Total do Item",
+							"example": 1000,
+							"minimum": 0,
+							"maximum": 999999999.99
+						},
+						"seguro": {
+							"type": "number",
+							"description": "Valor de Seguro por Item",
+							"example": 1000,
+							"minimum": 0,
+							"maximum": 999999999.99
+						},
+						"valor_csll": {
+							"type": "number",
+							"description": "Valor de CSLL",
+							"example": 1000,
+							"minimum": 0,
+							"maximum": 999999999.99
+						},
+						"valor_unitario": {
+							"type": "number",
+							"description": "Valor Unitário",
+							"example": 1000,
+							"minimum": 0,
+							"maximum": 999999999.99
+						},
+						"quantidade": {
+							"type": "number",
+							"description": "Quantidade do Item",
+							"example": 10,
+							"minimum": 0,
+							"maximum": 999999999.99
+						},
+						"aliquota_pis": {
+							"type": "number",
+							"description": "Alíquota do PIS/PASEP",
+							"example": 1.65,
+							"minimum": 0,
+							"maximum": 999999999.99
+						},
+						"aliquota_ipi": {
+							"type": "number",
+							"description": "Alíquota do IPI",
+							"example": 10,
+							"minimum": 0,
+							"maximum": 999999999.99
+						},
+						"valor_pis": {
+							"type": "number",
+							"description": "Valor do PIS/PASEP",
+							"example": 16.50,
+							"minimum": 0,
+							"maximum": 999999999.99
+						},
+						"aliquota_cofins": {
+							"type": "number",
+							"description": "Alíquota do COFINS",
+							"example": 7.6,
+							"minimum": 0,
+							"maximum": 999999999.99
+						},
+						"valor_cofins": {
+							"type": "number",
+							"description": "Valor do COFINS",
+							"example": 76,
+							"minimum": 0,
+							"maximum": 999999999.99
+						},
+						"aliquota_st": {
+							"type": "number",
+							"description": "Aliquota do ICMS-ST",
+							"example": 2,
+							"minimum": 0,
+							"maximum": 999999999.99
+						},
+						"aliquota_icms": {
+							"type": "number",
+							"description": "Aliquota do ICMS",
+							"example": 18,
+							"minimum": 0,
+							"maximum": 999999999.99
+						},
+						"frete": {
+							"type": "number",
+							"description": "Frete do Item",
+							"example": 100,
+							"minimum": 0,
+							"maximum": 999999999.99
+						},
+						"codigo_produto": {
+							"type": "string",
+							"description": "Código do Produto",
+							"example": "000000000000000000000000000001"
+						},
+						"aliquota_csll": {
+							"type": "number",
+							"description": "Aliquota do CSLL",
+							"example": 3,
+							"minimum": 0,
+							"maximum": 999999999.99
+						},
+						"valor_icms": {
+							"type": "number",
+							"description": "Valor do ICMS",
+							"example": 180,
+							"minimum": 0,
+							"maximum": 999999999.99
+						},
+						"valor_ipi": {
+							"type": "number",
+							"description": "Valor do IPI",
+							"example": 100,
+							"minimum": 0,
+							"maximum": 999999999.99
+						},
+						"desconto": {
+							"type": "number",
+							"description": "Desconto do Item",
+							"example": 10,
+							"minimum": 0,
+							"maximum": 999999999.99
+						},
+						"despesas_acessorias": {
+							"type": "number",
+							"description": "Despesas Acessórias do Item",
+							"example": 10,
+							"minimum": 0,
+							"maximum": 999999999.99
+						},
+						"tes": {
+							"type": "string",
+							"description": "Tipo de Entrada/Saída do Item",
+							"example": "501"
+						}
+					}
+				},
+				"desconto": {
+					"description": "Total de Descontos",
+					"example": 99.35,
+					"type": "number",
+					"minimum": 0,
+					"maximum": 999999999.99
+				},
+				"base_duplicada": {
+					"description": "Total do Título Financeiro",
+					"example": 99.35,
+					"type": "number",
+					"minimum": 0,
+					"maximum": 999999999.99
+				},
+				"seguro": {
+					"description": "Total do Seguro",
+					"example": 99.35,
+					"type": "number",
+					"minimum": 0,
+					"maximum": 999999999.99
+				},
+				"frete": {
+					"description": "Total do Frete",
+					"example": 99.35,
+					"type": "number",
+					"minimum": 0,
+					"maximum": 999999999.99
+				},
+				"despesas_acessorias": {
+					"description": "Total das Despesas Acessórias",
+					"example": 99.35,
+					"type": "number",
+					"minimum": 0,
+					"maximum": 999999999.99
 				}
 			}
 		},


### PR DESCRIPTION
O retorno dos valores de PIS e COFINS por item foram atualizados. A API estava retornando somente o PIS/COFINS via retenção, agora foram adicionadas as tags referentes ao PIS/COFINS via apuração e ao PIS/COFINS de substituição tributária.