### PR TITLE
Correção API e SCHEMA ITEMSKU

### DIFF
--- a/jsonschema/apis/ItemSKU_v2_000.json
+++ b/jsonschema/apis/ItemSKU_v2_000.json
@@ -68,7 +68,7 @@
 					"content": {
 						"application/json": {
 							"schema": {
-								"$ref": "https://raw.githubusercontent.com/totvs/ttalk-standard-message/master/jsonschema/schemas/ItemSKU_2_000.json#/definitions/PagedItemSKU"
+								"$ref": "https://raw.githubusercontent.com/totvs/ttalk-standard-message/master/jsonschema/schemas/ItemSKU_2_000.json#/definitions/ItemSKUInfo"
 							}
 						}
 					}
@@ -79,7 +79,7 @@
 						"content": {
 							"application/json": {
 								"schema": {
-									"$ref": "https://raw.githubusercontent.com/totvs/ttalk-standard-message/master/jsonschema/schemas/ItemSKU_2_000.json#/definitions/PagedItemSKU"
+									"$ref": "https://raw.githubusercontent.com/totvs/ttalk-standard-message/master/jsonschema/schemas/ItemSKU_2_000.json#/definitions/ItemSKUInfo"
 								}
 							}
 						}
@@ -140,7 +140,7 @@
 					"content": {
 						"application/json": {
 							"schema": {
-								"$ref": "https://raw.githubusercontent.com/totvs/ttalk-standard-message/master/jsonschema/schemas/ItemSKU_2_000.json#/definitions/PagedItemSKU"
+								"$ref": "https://raw.githubusercontent.com/totvs/ttalk-standard-message/master/jsonschema/schemas/ItemSKU_2_000.json#/definitions/ItemSKUInfo"
 							}
 						}
 					}
@@ -151,7 +151,7 @@
 						"content": {
 							"application/json": {
 								"schema": {
-									"$ref": "https://raw.githubusercontent.com/totvs/ttalk-standard-message/master/jsonschema/schemas/ItemSKU_2_000.json#/definitions/PagedItemSKU"
+									"$ref": "https://raw.githubusercontent.com/totvs/ttalk-standard-message/master/jsonschema/schemas/ItemSKU_2_000.json#/definitions/ItemSKUInfo"
 								}
 							}
 						}

--- a/jsonschema/schemas/ItemSKU_2_000.json
+++ b/jsonschema/schemas/ItemSKU_2_000.json
@@ -17,29 +17,10 @@
                "contact":"SUPPLY.LOG.WMS-OL@totvs.com.br",
                "note":"Cadastro de Item/SKU"
             }
-         ],
+         ]
       }
    },
-   "definitions":{
-      "PagedItemSKU":{
-         "type":"object",
-         "allOf":[
-            {
-               "$ref":"https://raw.githubusercontent.com/totvs/ttalk-standard-message/master/jsonschema/apis/types/totvsApiTypesBase.json#/definitions/Paging"
-            },
-            {
-               "type":"object",
-               "properties":{
-                  "items":{
-                     "type":"array",
-                     "items":{
-                        "$ref":"#/definitions/ItemSKUInfo"
-                     }
-                  }
-               }
-            }
-         ]
-      },
+   "definitions":{      
       "ItemSKUInfo":{
          "type":"object",
          "properties":{
@@ -529,7 +510,7 @@
             },
             "ListOfSKU":{
                "type":"array",
-               "multipleOf":0.0001,
+               "multipleOf":1,
                "items":{
                   "type":"object",
                   "properties":{
@@ -575,7 +556,7 @@
                      "NumberOfItems":{
                         "description":"Quantidade Itens por SKU",
                         "type":"number",
-                        "multipleOf":0.00001,
+                        "multipleOf":0.000001,
                         "minimum":0.000000,
                         "maximum":99999999999.999999,
                         "x-totvs":[
@@ -590,7 +571,7 @@
                      "Height":{
                         "description":"Altura SKU",
                         "type":"number",
-                        "multipleOf":0.00001,
+                        "multipleOf":0.000001,
                         "minimum":0.000000,
                         "maximum":99999999999.999999,
                         "x-totvs":[
@@ -605,7 +586,7 @@
                      "Length":{
                         "description":"Comprimento SKU",
                         "type":"number",
-                        "multipleOf":0.00001,
+                        "multipleOf":0.000001,
                         "minimum":0.000000,
                         "maximum":99999999999.999999,
                         "x-totvs":[
@@ -620,7 +601,7 @@
                      "Width":{
                         "description":"Largura SKU",
                         "type":"number",
-                        "multipleOf":0.00001,
+                        "multipleOf":0.000001,
                         "minimum":0.000000,
                         "maximum":99999999999.999999,
                         "x-totvs":[
@@ -635,9 +616,9 @@
                      "HeightBoxes":{
                         "description":"Quantidade Caixas Altura",
                         "type":"number",
-                        "multipleOf":0.00001,
-                        "minimum":0.000000,
-                        "maximum":99999999999.999999,
+                        "multipleOf":1,
+                        "minimum":1,
+                        "maximum":9999999999,
                         "x-totvs":[
                            {
                               "product":"Logix",
@@ -650,9 +631,9 @@
                      "BallastBoxes":{
                         "description":"Quantidade Caixas Lastro",
                         "type":"number",
-                        "multipleOf":0.00001,
-                        "minimum":0.000000,
-                        "maximum":99999999999.999999,
+                        "multipleOf":1,
+                        "minimum":1,
+                        "maximum":9999999999,
                         "x-totvs":[
                            {
                               "product":"Logix",
@@ -665,7 +646,7 @@
                      "GrossWeight":{
                         "description":"Peso Bruto",
                         "type":"number",
-                        "multipleOf":0.00001,
+                        "multipleOf":0.000001,
                         "minimum":0.000000,
                         "maximum":99999999999.999999,
                         "x-totvs":[
@@ -745,7 +726,7 @@
                      "Ean13UpcDun14":{
                         "description":"Código Ean13/Upc/Dun14",
                         "type":"string",
-                        "maxLength":128,
+                        "maxLength":14,
                         "x-totvs":[
                            {
                               "product":"Logix",


### PR DESCRIPTION
A definição indicava que o item poderia ser um array, no entanto as requisições deverão ser únicas por produto. Também corrigida a definição de campos decimais.