### PR TITLE
Ajuste de External autonomous payment 1.007

### DIFF
--- a/jsonschema/schemas/ExternalAutonomousPayment_1_007.json
+++ b/jsonschema/schemas/ExternalAutonomousPayment_1_007.json
@@ -1023,33 +1023,6 @@
         "DataAutonomosDependentType" :{
             "type": "object",
             "properties" :{
-				"InternalId": {
-					"description": "Código identificador do registro",
-					"type": "integer",
-					"format": "int32",
-					"x-totvs": [
-						{
-							"product": "RM",
-							"field": "PPAGTOAUTONOMOEXTDEPEND.CODCOLIGADA | PPAGTOAUTONOMOEXTDEPEND.CODIGOPAGTO",
-							"required": true,
-							"type": "Inteiro",
-							"length": "4",
-							"note": "Código identificador do registro",
-							"available": true,
-							"canUpdate": false
-						},
-						{
-							"product": "PROTHEUS",
-							"field": "",
-							"required": true,
-							"type": "",
-							"length": "",
-							"note": "",
-							"available": true,
-							"canUpdate": false
-						}
-					]
-				},
 				"DependentId": {
 					"description": "CPF do dependente",
 					"type": "string",

--- a/jsonschema/schemas/ExternalAutonomousPayment_1_007.json
+++ b/jsonschema/schemas/ExternalAutonomousPayment_1_007.json
@@ -1,0 +1,1245 @@
+{
+	"$schema": "https://raw.githubusercontent.com/totvs/ttalk-standard-message/master/jsonschema/schemas/ExternalAutonomousPayment_1_006.json#",
+	"info": {
+		"description": "",
+		"version": "1.007",
+		"title": "ExternalAutonomousPayment",
+		"contact": {},
+		"x-totvs": {
+			"messageDocumentation": {
+				"name": "ExternalAutonomousPayment",
+				"description": "Pagamento de Autônomos Externos",
+				"segment": "Recursos Humanos"
+			},
+			"productInformation": [
+				{
+					"product": "RM",
+					"contact": "Simone Cristina dos Reis Gonçalves",
+					"note": "",
+					"adapter": ""
+				},
+				{
+					"product": "PROTHEUS",
+					"contact": "Rogerio Nagy",
+					"note": "",
+					"adapter": ""
+				}
+			],
+			"transactionDefinition": {
+				"subType": "event",
+				"businessContentType": {
+					"$ref": "#/definitions/BusinessContentType",
+					"type": "object"
+				}
+			}
+		}
+	},
+	"definitions": {
+		"BusinessContentType": {
+			"type": "object",
+			"properties": {
+				"ListOfAutonomous": {
+					"description": "Lista de lançamentos",
+					"type": "array",
+					"items": {
+						"$ref": "#/definitions/DataAutonomosType",
+						"type": "object"
+					}
+				}
+			}
+		},
+		"DataAutonomosType": {
+			"type": "object",
+			"properties": {
+				"CompanyId": {
+					"description": "Código da Empresa",
+					"type": "integer",
+					"format": "int32",
+					"x-totvs": [
+						{
+							"product": "RM",
+							"field": "PPAGTOAUTONOMOEXT.CODCOLIGADA",
+							"required": true,
+							"type": "DCOLIGADA",
+							"length": "2",
+							"note": "Código da Empresa",
+							"available": true,
+							"canUpdate": false
+						},
+						{
+							"product": "PROTHEUS",
+							"field": "",
+							"required": true,
+							"type": "",
+							"length": "",
+							"note": "",
+							"available": true,
+							"canUpdate": false
+						}
+					]
+				},
+				"BranchId": {
+					"description": "Código da Filial fiscal (estabelecimento)",
+					"type": "integer",
+					"minimum": -32768,
+					"maximum": 32767,
+					"format": "int32",
+					"x-totvs": [
+						{
+							"product": "RM",
+							"field": "PPAGTOAUTONOMOEXT.CODFILIAL",
+							"required": false,
+							"type": "Short",
+							"length": "4",
+							"note": "Código da Filial fiscal (estabelecimento)",
+							"available": true,
+							"canUpdate": false
+						},
+						{
+							"product": "PROTHEUS",
+							"field": "",
+							"required": true,
+							"type": "",
+							"length": "",
+							"note": "",
+							"available": true,
+							"canUpdate": false
+						}
+					]
+				},
+				"CompanyInternalId": {
+					"description": "Código da Empresa|Código da Filial",
+					"type": "integer",
+					"format": "int32",
+					"x-totvs": [
+						{
+							"product": "RM",
+							"field": "PPAGTOAUTONOMOEXT.CODCOLIGADA|PPAGTOAUTONOMOEXT.CODFILIAL",
+							"required": true,
+							"type": "",
+							"length": "",
+							"note": "Código da Empresa|Código da Filial",
+							"available": true,
+							"canUpdate": false
+						},
+						{
+							"product": "PROTHEUS",
+							"field": "",
+							"required": true,
+							"type": "",
+							"length": "",
+							"note": "",
+							"available": true,
+							"canUpdate": false
+						}
+					]
+				},
+				"InternalId": {
+					"description": "Código identificador do registro",
+					"type": "integer",
+					"format": "int32",
+					"x-totvs": [
+						{
+							"product": "RM",
+							"field": "PPAGTOAUTONOMOEXT.CODCOLIGADA|PPAGTOAUTONOMOEXT.CODIGO",
+							"required": true,
+							"type": "Inteiro",
+							"length": "4",
+							"note": "Código identificador do registro",
+							"available": true,
+							"canUpdate": false
+						},
+						{
+							"product": "PROTHEUS",
+							"field": "",
+							"required": true,
+							"type": "",
+							"length": "",
+							"note": "",
+							"available": true,
+							"canUpdate": false
+						}
+					]
+				},
+				"TakerId": {
+					"description": "CNPJ do tomador de serviços onde o autônomo prestou o serviço",
+					"type": "string",
+					"maxLength": 20,
+					"x-totvs": [
+						{
+							"product": "RM",
+							"field": "PPAGTOAUTONOMOEXT.CNPJTOMADOR",
+							"required": false,
+							"type": "Texto",
+							"length": "20",
+							"note": "CNPJ do tomador de serviços onde o autônomo prestou o serviço",
+							"available": true,
+							"canUpdate": false
+						},
+						{
+							"product": "PROTHEUS",
+							"field": "",
+							"required": false,
+							"type": "",
+							"length": "",
+							"note": "",
+							"available": true,
+							"canUpdate": false
+						}
+					]
+				},
+				"TakerSpecificId": {
+					"description": "CEI do Tomador de serviços, quando o tipo do tomador for Construção Civil",
+					"type": "string",
+					"maxLength": 20,
+					"x-totvs": [
+						{
+							"product": "RM",
+							"field": "PPAGTOAUTONOMOEXT.CEITOMADOR",
+							"required": false,
+							"type": "Texto",
+							"length": "20",
+							"note": "Requerido se TakerType  = 2 (Construção Civil)",
+							"available": true,
+							"canUpdate": false
+						},
+						{
+							"product": "PROTHEUS",
+							"field": "",
+							"required": false,
+							"type": "",
+							"length": "",
+							"note": "",
+							"available": true,
+							"canUpdate": false
+						}
+					]
+				},
+				"TakerType": {
+					"description": "O serviço foi executado para o segmento  1 = Cessão Mão de Obra ou 2 = Construção Civil",
+					"type": "integer",
+					"format": "int32",
+					"x-totvs": [
+						{
+							"product": "RM",
+							"field": "PPAGTOAUTONOMOEXT.TPTOMADOR",
+							"required": false,
+							"type": "SmallInt",
+							"length": "2",
+							"note": "Requerido se TakerID diferente de Nulo",
+							"available": true,
+							"canUpdate": false
+						},
+						{
+							"product": "PROTHEUS",
+							"field": "",
+							"required": false,
+							"type": "",
+							"length": "",
+							"note": "",
+							"available": true,
+							"canUpdate": false
+						}
+					]
+				},
+				"AutonomousName": {
+					"description": "Nome do fornecedor – Nome do Autônomo",
+					"type": "string",
+					"maxLength": 100,
+					"x-totvs": [
+						{
+							"product": "RM",
+							"field": "PPAGTOAUTONOMOEXT.NOMEAUTONOMO",
+							"required": true,
+							"type": "Texto",
+							"length": "100",
+							"note": "Nome do fornecedor – Nome do Autônomo",
+							"available": true,
+							"canUpdate": false
+						},
+						{
+							"product": "PROTHEUS",
+							"field": "",
+							"required": true,
+							"type": "",
+							"length": "",
+							"note": "",
+							"available": true,
+							"canUpdate": false
+						}
+					]
+				},
+				"DateOfBirth": {
+					"description": "Data de Nascimento do trabalhador/autônomo",
+					"type": "string",
+					"format": "date",
+					"x-totvs": [
+						{
+							"product": "RM",
+							"field": "PPAGTOAUTONOMOEXT.DTNASCIMENTO",
+							"required": true,
+							"type": "Data",
+							"length": "8",
+							"note": "Data de Nascimento do trabalhador/autônomo",
+							"available": true,
+							"canUpdate": false
+						},
+						{
+							"product": "PROTHEUS",
+							"field": "",
+							"required": true,
+							"type": "",
+							"length": "",
+							"note": "",
+							"available": true,
+							"canUpdate": false
+						}
+					]
+				},
+				"AutonomousId": {
+					"description": "CPF do trabalhador/autônomo",
+					"type": "string",
+					"maxLength": 11,
+					"x-totvs": [
+						{
+							"product": "RM",
+							"field": "PPAGTOAUTONOMOEXT.CPF",
+							"required": true,
+							"type": "Texto",
+							"length": "11",
+							"note": "CPF do trabalhador/autônomo",
+							"available": true,
+							"canUpdate": false
+						},
+						{
+							"product": "PROTHEUS",
+							"field": "",
+							"required": true,
+							"type": "",
+							"length": "",
+							"note": "",
+							"available": true,
+							"canUpdate": false
+						}
+					]
+				},
+				"RegistrationNumber": {
+					"description": "Informação no cadastro do autônomo  (entidade cliente/fornecedor do módulo financeiro)  - Número de Inscrição do Trabalhador (NIT)",
+					"type": "string",
+					"maxLength": 11,
+					"x-totvs": [
+						{
+							"product": "RM",
+							"field": "PPAGTOAUTONOMOEXT.NROINSCRICAO",
+							"required": true,
+							"type": "Texto",
+							"length": "11",
+							"note": "Informação no cadastro do autônomo  (entidade cliente/fornecedor do módulo financeiro)  - Número de Inscrição do Trabalhador (NIT)",
+							"available": true,
+							"canUpdate": false
+						},
+						{
+							"product": "PROTHEUS",
+							"field": "",
+							"required": true,
+							"type": "",
+							"length": "",
+							"note": "",
+							"available": true,
+							"canUpdate": false
+						}
+					]
+				},
+				"AutonomousOcupationNationalCode": {
+					"description": "Código Brasileiro de Ocupação do Autônomo",
+					"type": "string",
+					"maxLength": 10,
+					"x-totvs": [
+						{
+							"product": "RM",
+							"field": "PPAGTOAUTONOMOEXT.CBOAUTONOMO",
+							"required": true,
+							"type": "Texto",
+							"length": "10",
+							"note": "Informação no cadastro do autônomo  (entidade cliente/fornecedor do módulo financeiro)",
+							"available": true,
+							"canUpdate": false
+						},
+						{
+							"product": "PROTHEUS",
+							"field": "",
+							"required": true,
+							"type": "",
+							"length": "",
+							"note": "",
+							"available": true,
+							"canUpdate": false
+						}
+					]
+				},
+				"AutonomousCategory": {
+					"description": "Informação é tabelada. Amarrada no cadastro do autônomo  (entidade cliente/fornecedor do módulo financeiro)",
+					"type": "string",
+					"maxLength": 10,
+					"x-totvs": [
+						{
+							"product": "RM",
+							"field": "PPAGTOAUTONOMOEXT.CATAUTONOMO",
+							"required": true,
+							"type": "SmallInt",
+							"length": "2",
+							"note": "Informação é tabelada. Amarrada no cadastro do autônomo  (entidade cliente/fornecedor do módulo financeiro)",
+							"available": true,
+							"canUpdate": false
+						},
+						{
+							"product": "PROTHEUS",
+							"field": "",
+							"required": true,
+							"type": "",
+							"length": "",
+							"note": "",
+							"available": true,
+							"canUpdate": false
+						}
+					]
+				},
+				"eSocialAutonomousCategory": {
+					"description": "Código da Categoria do eSocial em que prestou Serviço na Empresa",
+					"type": "integer",
+					"format": "int32",
+					"x-totvs": [
+						{
+							"product": "RM",
+							"field": "PPAGTOAUTONOMOEXT.CATEGORIAESOCIAL",
+							"required": true,
+							"type": "SmallInt",
+							"length": "2",
+							"note": "Código da Categoria do eSocial em que prestou Serviço na Empresa",
+							"available": true,
+							"canUpdate": false
+						},
+						{
+							"product": "PROTHEUS",
+							"field": "",
+							"required": true,
+							"type": "",
+							"length": "",
+							"note": "",
+							"available": true,
+							"canUpdate": false
+						}
+					]
+				},
+				"SefipEventCode": {
+					"description": "Código Ocorrência Sefip",
+					"type": "integer",
+					"format": "int32",
+					"x-totvs": [
+						{
+							"product": "RM",
+							"field": "PPAGTOAUTONOMOEXT.CODOCORSEFIP",
+							"required": true,
+							"type": "SmallInt",
+							"length": "2",
+							"note": "Informação tabelada. Amarrada no cadastro do autônomo  (entidade cliente/fornecedor do módulo financeiro)",
+							"available": true,
+							"canUpdate": false
+						},
+						{
+							"product": "PROTHEUS",
+							"field": "",
+							"required": true,
+							"type": "",
+							"length": "",
+							"note": "",
+							"available": true,
+							"canUpdate": false
+						}
+					]
+				},
+				"IssueDate": {
+					"description": "Data da Emissão do Pagamento",
+					"type": "string",
+					"format": "date",
+					"x-totvs": [
+						{
+							"product": "RM",
+							"field": "PPAGTOAUTONOMOEXT.DATAEMISSAO",
+							"required": true,
+							"type": "Data",
+							"length": "8",
+							"note": "Data da Emissão do Pagamento",
+							"available": true,
+							"canUpdate": false
+						},
+						{
+							"product": "PROTHEUS",
+							"field": "",
+							"required": true,
+							"type": "",
+							"length": "",
+							"note": "",
+							"available": true,
+							"canUpdate": false
+						}
+					]
+				},
+				"DueDate": {
+					"description": "Data do Vencimento do Pagamento",
+					"type": "string",
+					"format": "date",
+					"x-totvs": [
+						{
+							"product": "RM",
+							"field": "PPAGTOAUTONOMOEXT.DATAVENCIMENTO",
+							"required": true,
+							"type": "Data",
+							"length": "8",
+							"note": "Data do Vencimento do Pagamento",
+							"available": true,
+							"canUpdate": false
+						},
+						{
+							"product": "PROTHEUS",
+							"field": "",
+							"required": true,
+							"type": "",
+							"length": "",
+							"note": "",
+							"available": true,
+							"canUpdate": false
+						}
+					]
+				},
+				"InitiationDate": {
+					"description": "Primeiro dia de prestação de serviço do autônomo",
+					"type": "string",
+					"format": "date",
+					"x-totvs": [
+						{
+							"product": "RM",
+							"field": "PPAGTOAUTONOMOEXT.DATAINIATIVIDADE",
+							"required": true,
+							"type": "Data",
+							"length": "8",
+							"note": "Primeiro dia de prestação de serviço do autônomo",
+							"available": true,
+							"canUpdate": false
+						},
+						{
+							"product": "PROTHEUS",
+							"field": "",
+							"required": true,
+							"type": "",
+							"length": "",
+							"note": "",
+							"available": true,
+							"canUpdate": false
+						}
+					]
+				},
+				"ServiceNature": {
+					"description": "Natureza do serviço (Atividade Rural ou Urbana)",
+					"type": "integer",
+					"format": "int32",
+					"x-totvs": [
+						{
+							"product": "RM",
+							"field": "PPAGTOAUTONOMOEXT.NATUREZAATIV",
+							"required": false,
+							"type": "SmallInt",
+							"length": "2",
+							"note": "Natureza do serviço (Atividade Rural ou Urbana)",
+							"available": true,
+							"canUpdate": false
+						},
+						{
+							"product": "PROTHEUS",
+							"field": "",
+							"required": false,
+							"type": "",
+							"length": "",
+							"note": "",
+							"available": true,
+							"canUpdate": false
+						}
+					]
+				},
+				"DependentsNumber": {
+					"description": "Quantidade de Dependentes Salário família",
+					"type": "integer",
+					"format": "int32",
+					"x-totvs": [
+						{
+							"product": "RM",
+							"field": "PPAGTOAUTONOMOEXT.QTDDEPSF",
+							"required": false,
+							"type": "Inteiro",
+							"length": "4",
+							"note": "Campo obrigatório para o eSocial",
+							"available": true,
+							"canUpdate": false
+						},
+						{
+							"product": "PROTHEUS",
+							"field": "",
+							"required": false,
+							"type": "",
+							"length": "",
+							"note": "",
+							"available": true,
+							"canUpdate": false
+						}
+					]
+				},
+				"IRRFDependentsNumber": {
+					"description": "Quantidade de Dependentes IRRF",
+					"type": "integer",
+					"format": "int32",
+					"x-totvs": [
+						{
+							"product": "RM",
+							"field": "PPAGTOAUTONOMOEXT.QTDDEPIRRF",
+							"required": false,
+							"type": "Inteiro",
+							"length": "4",
+							"note": "Campo obrigatório para o eSocial",
+							"available": true,
+							"canUpdate": false
+						},
+						{
+							"product": "PROTHEUS",
+							"field": "",
+							"required": false,
+							"type": "",
+							"length": "",
+							"note": "",
+							"available": true,
+							"canUpdate": false
+						}
+					]
+				},
+				"PaymentValue": {
+					"description": "Remuneração, valor bruto",
+					"type": "number",
+					"format": "double",
+					"x-totvs": [
+						{
+							"product": "RM",
+							"field": "PPAGTOAUTONOMOEXT.VALORBRUTO",
+							"required": true,
+							"type": "Decimal",
+							"length": "9",
+							"note": "Remuneração, valor bruto",
+							"available": true,
+							"canUpdate": false
+						},
+						{
+							"product": "PROTHEUS",
+							"field": "",
+							"required": true,
+							"type": "",
+							"length": "",
+							"note": "",
+							"available": true,
+							"canUpdate": false
+						}
+					]
+				},
+				"INSSValue": {
+					"description": "Valor do INSS descontado do segurado",
+					"type": "number",
+					"format": "double",
+					"x-totvs": [
+						{
+							"product": "RM",
+							"field": "PPAGTOAUTONOMOEXT.VALORINSS",
+							"required": true,
+							"type": "Decimal",
+							"length": "8",
+							"note": "Valor do INSS descontado do segurado",
+							"available": true,
+							"canUpdate": false
+						},
+						{
+							"product": "PROTHEUS",
+							"field": "",
+							"required": true,
+							"type": "",
+							"length": "",
+							"note": "",
+							"available": true,
+							"canUpdate": false
+						}
+					]
+				},
+				"PaymentDate": {
+					"description": "Data do Pagamento",
+					"type": "string",
+					"format": "date",
+					"x-totvs": [
+						{
+							"product": "RM",
+							"field": "PPAGTOAUTONOMOEXT.DATAPAGAMENTO",
+							"required": false,
+							"type": "Data",
+							"length": "8",
+							"note": "Data do Pagamento",
+							"available": true,
+							"canUpdate": false
+						},
+						{
+							"product": "PROTHEUS",
+							"field": "",
+							"required": false,
+							"type": "",
+							"length": "",
+							"note": "",
+							"available": true,
+							"canUpdate": false
+						}
+					]
+				},
+				"IRRFValue": {
+					"description": "Valor do IRRF",
+					"type": "number",
+					"format": "double",
+					"x-totvs": [
+						{
+							"product": "RM",
+							"field": "PPAGTOAUTONOMOEXT.VALORIRRF",
+							"required": false,
+							"type": "Decimal",
+							"length": "8",
+							"note": "Valor do IRRF descontado do segurado",
+							"available": true,
+							"canUpdate": false
+						},
+						{
+							"product": "PROTHEUS",
+							"field": "",
+							"required": false,
+							"type": "",
+							"length": "",
+							"note": "",
+							"available": true,
+							"canUpdate": false
+						}
+					]
+				},
+				"MultipleEmploymentIndicator": {
+					"description": "Indicador de desconto da contribuição em outro emprego",
+					"type": "integer",
+					"format": "int32",
+					"x-totvs": [
+						{
+							"product": "RM",
+							"field": "PPAGTOAUTONOMOEXT.INDMV",
+							"required": false,
+							"type": "SmallInt",
+							"length": "2",
+							"note": "Indicador de desconto da contribuição em outro emprego",
+							"available": true,
+							"canUpdate": false
+						},
+						{
+							"product": "PROTHEUS",
+							"field": "",
+							"required": false,
+							"type": "",
+							"length": "",
+							"note": "",
+							"available": true,
+							"canUpdate": false
+						}
+					]
+				},
+				"OtherEmployments": {
+					"description": "Informações relativas ao trabalhador que possui vínculo empregatício com outra(s) empresa(s)",
+					"type": "array",
+					"items": {
+						"$ref": "#/definitions/OtherEmploymentType",
+						"type": "object"
+					}
+				},
+				"ISSValue": {
+					"description": "Valor do ISS",
+					"type": "number",
+					"format": "double",
+					"x-totvs": [
+						{
+							"product": "RM",
+							"field": "PPAGTOAUTONOMOEXT.VALORISS",
+							"required": false,
+							"type": "Decimal",
+							"length": "8",
+							"note": "Valor do ISS",
+							"available": true,
+							"canUpdate": false
+						},
+						{
+							"product": "PROTHEUS",
+							"field": "",
+							"required": false,
+							"type": "",
+							"length": "",
+							"note": "",
+							"available": true,
+							"canUpdate": false
+						}
+					]
+				},
+				"SESTValue": {
+					"description": "Valor do SEST",
+					"type": "number",
+					"format": "double",
+					"x-totvs": [
+						{
+							"product": "RM",
+							"field": "PPAGTOAUTONOMOEXT.VALORSEST",
+							"required": false,
+							"type": "Decimal",
+							"length": "8",
+							"note": "Valor do SEST",
+							"available": true,
+							"canUpdate": false
+						},
+						{
+							"product": "PROTHEUS",
+							"field": "",
+							"required": false,
+							"type": "",
+							"length": "",
+							"note": "",
+							"available": true,
+							"canUpdate": false
+						}
+					]
+				},
+				"SENATValue": {
+					"description": "Valor do SENAT",
+					"type": "number",
+					"format": "double",
+					"x-totvs": [
+						{
+							"product": "RM",
+							"field": "PPAGTOAUTONOMOEXT.VALORSENAT",
+							"required": false,
+							"type": "Decimal",
+							"length": "8",
+							"note": "Valor do SENAT",
+							"available": true,
+							"canUpdate": false
+						},
+						{
+							"product": "PROTHEUS",
+							"field": "",
+							"required": false,
+							"type": "",
+							"length": "",
+							"note": "",
+							"available": true,
+							"canUpdate": false
+						}
+					]
+				},
+				"FreightRemunerationValue": {
+					"description": "Provento de remuneração de frete",
+					"type": "number",
+					"format": "double",
+					"x-totvs": [
+						{
+							"product": "RM",
+							"field": "PPAGTOAUTONOMOEXT.VALORREMUNERACAOFRETE",
+							"required": false,
+							"type": "Decimal",
+							"length": "8",
+							"note": "Provento de remuneração de frete",
+							"available": true,
+							"canUpdate": false
+						},
+						{
+							"product": "PROTHEUS",
+							"field": "",
+							"required": false,
+							"type": "",
+							"length": "",
+							"note": "",
+							"available": true,
+							"canUpdate": false
+						}
+					]
+				},
+				"RemunerationValueWithIRRFIncidence": {
+					"description": "Provento de remuneração de frete com incidência em IRRF",
+					"type": "number",
+					"format": "double",
+					"x-totvs": [
+						{
+							"product": "RM",
+							"field": "PPAGTOAUTONOMOEXT.VALORREMUNFRETEINCIDEIRRF",
+							"required": false,
+							"type": "Decimal",
+							"length": "8",
+							"note": "Provento de remuneração de frete com incidência em IRRF",
+							"available": true,
+							"canUpdate": false
+						},
+						{
+							"product": "PROTHEUS",
+							"field": "",
+							"required": false,
+							"type": "",
+							"length": "",
+							"note": "",
+							"available": true,
+							"canUpdate": false
+						}
+					]
+				},
+				"RemunerationValueWithINSSIncidence": {
+					"description": "Provento de remuneração de frete com incidência em INSS",
+					"type": "number",
+					"format": "double",
+					"x-totvs": [
+						{
+							"product": "RM",
+							"field": "PPAGTOAUTONOMOEXT.VALORREMUNFRETEINCIDEINSS",
+							"required": false,
+							"type": "Decimal",
+							"length": "8",
+							"note": "Provento de remuneração de frete com incidência em INSS",
+							"available": true,
+							"canUpdate": false
+						},
+						{
+							"product": "PROTHEUS",
+							"field": "",
+							"required": false,
+							"type": "",
+							"length": "",
+							"note": "",
+							"available": true,
+							"canUpdate": false
+						}
+					]
+				},
+				"ListOfDependents":{
+					"description": "Dependentes do autônomo externo",
+					"type":"array",
+					"items":{
+						"$ref": "#/definitions/DataAutonomosDependentType",
+						"type": "object"
+					}
+				}
+			}
+		},
+		"OtherEmploymentType": {
+			"type": "object",
+			"properties": {
+				"OtherEmploymentId": {
+					"description": "CNPJ em que o Autônomo Externo prestou Serviço",
+					"type": "string",
+					"x-totvs": [
+						{
+							"product": "RM",
+							"field": "PPAGTOAUTONOMOEXT.CNPJREMUNOUTREMPR",
+							"required": false,
+							"type": "TaxType",
+							"length": "20",
+							"note": "CNPJ em que o Autônomo Externo prestou Serviço",
+							"available": true,
+							"canUpdate": false
+						},
+						{
+							"product": "PROTHEUS",
+							"field": "",
+							"required": false,
+							"type": "",
+							"length": "",
+							"note": "",
+							"available": true,
+							"canUpdate": false
+						}
+					]
+				},
+				"OtherEmploymentCategory": {
+					"description": "Código da Categoria do eSocial em que prestou Serviço referente a outro emprego (Múltiplos Vínculos)",
+					"type": "integer",
+					"format": "int32",
+					"x-totvs": [
+						{
+							"product": "RM",
+							"field": "PPAGTOAUTONOMOEXT.CODCATEG",
+							"required": false,
+							"type": "SmallInt",
+							"length": "2",
+							"note": "Código da Categoria do eSocial em que prestou Serviço referente a outro emprego (Múltiplos Vínculos)",
+							"available": true,
+							"canUpdate": false
+						},
+						{
+							"product": "PROTHEUS",
+							"field": "",
+							"required": false,
+							"type": "",
+							"length": "",
+							"note": "",
+							"available": true,
+							"canUpdate": false
+						}
+					]
+				},
+				"OtherEmploymentINSSBasis": {
+					"description": "Base de INSS",
+					"type": "number",
+					"format": "double",
+					"x-totvs": [
+						{
+							"product": "RM",
+							"field": "PPAGTOAUTONOMOEXT.VALORINSSOUTROEMPREGO",
+							"required": false,
+							"type": "Decimal",
+							"length": "8",
+							"note": "Base de INSS",
+							"available": true,
+							"canUpdate": false
+						},
+						{
+							"product": "PROTHEUS",
+							"field": "",
+							"required": false,
+							"type": "",
+							"length": "",
+							"note": "",
+							"available": true,
+							"canUpdate": false
+						}
+					]
+				}
+			}
+		},
+        "DataAutonomosDependentType" :{
+            "type": "object",
+            "properties" :{
+				"InternalId": {
+					"description": "Código identificador do registro",
+					"type": "integer",
+					"format": "int32",
+					"x-totvs": [
+						{
+							"product": "RM",
+							"field": "PPAGTOAUTONOMOEXTDEPEND.CODCOLIGADA | PPAGTOAUTONOMOEXTDEPEND.CODIGOPAGTO",
+							"required": true,
+							"type": "Inteiro",
+							"length": "4",
+							"note": "Código identificador do registro",
+							"available": true,
+							"canUpdate": false
+						},
+						{
+							"product": "PROTHEUS",
+							"field": "",
+							"required": true,
+							"type": "",
+							"length": "",
+							"note": "",
+							"available": true,
+							"canUpdate": false
+						}
+					]
+				},
+				"DependentId": {
+					"description": "CPF do dependente",
+					"type": "string",
+					"maxLength": 11,
+					"x-totvs": [
+						{
+							"product": "RM",
+							"field": "PPAGTOAUTONOMOEXTDEPEND.CPF",
+							"required": true,
+							"type": "Texto",
+							"length": "11",
+							"note": "CPF do dependente",
+							"available": true,
+							"canUpdate": false
+						},
+						{
+							"product": "PROTHEUS",
+							"field": "",
+							"required": true,
+							"type": "",
+							"length": "",
+							"note": "",
+							"available": true,
+							"canUpdate": false
+						}
+					]
+				},
+				"DependentName": {
+					"description": "Nome do dependente",
+					"type": "string",
+					"maxLength": 70,
+					"x-totvs": [
+						{
+							"product": "RM",
+							"field": "PPAGTOAUTONOMOEXTDEPEND.NOME",
+							"required": false,
+							"type": "Texto",
+							"length": "70",
+							"note": "Nome do dependente",
+							"available": true,
+							"canUpdate": false
+						},
+						{
+							"product": "PROTHEUS",
+							"field": "",
+							"required": true,
+							"type": "",
+							"length": "",
+							"note": "",
+							"available": true,
+							"canUpdate": false
+						}
+					]
+				},
+				"DependentBirthDate": {
+					"description": "Data de Nascimento do dependente",
+					"type": "string",
+					"format": "date",
+					"x-totvs": [
+						{
+							"product": "RM",
+							"field": "PPAGTOAUTONOMOEXTDEPEND.DTNASCIMENTO",
+							"required": true,
+							"type": "Data",
+							"length": "8",
+							"note": "Data de Nascimento do dependente",
+							"available": true,
+							"canUpdate": false
+						},
+						{
+							"product": "PROTHEUS",
+							"field": "",
+							"required": true,
+							"type": "",
+							"length": "",
+							"note": "",
+							"available": true,
+							"canUpdate": false
+						}
+					]
+				},
+				"DependentType": {
+					"description": "Tipo do dependente",
+					"type": "string",
+					"format": "int32",
+					"x-totvs": [
+						{
+							"product": "RM",
+							"field": "PPAGTOAUTONOMOEXTDEPEND.TIPODEPENDENTE",
+							"required": false,
+							"type": "Texto",
+							"length": "2",
+							"note": "Tipo do dependente",
+							"available": true,
+							"canUpdate": false
+						},
+						{
+							"product": "PROTHEUS",
+							"field": "",
+							"required": false,
+							"type": "",
+							"length": "",
+							"note": "",
+							"available": true,
+							"canUpdate": false
+						}
+					]
+				},
+				"DependencyDescription": {
+					"description": "Descrição da dependência",
+					"type": "string",
+					"maxLength": 100,
+					"x-totvs": [
+						{
+							"product": "RM",
+							"field": "PPAGTOAUTONOMOEXTDEPEND.DESCRICAODEPENDENCIA",
+							"required": false,
+							"type": "Texto",
+							"length": "100",
+							"note": "Descrição da dependência",
+							"available": true,
+							"canUpdate": false
+						},
+						{
+							"product": "PROTHEUS",
+							"field": "",
+							"required": true,
+							"type": "",
+							"length": "",
+							"note": "",
+							"available": true,
+							"canUpdate": false
+						}
+					]
+				},
+				"DeductionValue": {
+					"description": "Valor da dedução",
+					"type": "number",
+					"format": "double",
+					"x-totvs": [
+						{
+							"product": "RM",
+							"field": "PPAGTOAUTONOMOEXTDEPEND.VALORDEDUCAO",
+							"required": false,
+							"type": "Decimal",
+							"length": "8",
+							"note": "Valor da dedução",
+							"available": true,
+							"canUpdate": false
+						},
+						{
+							"product": "PROTHEUS",
+							"field": "",
+							"required": true,
+							"type": "",
+							"length": "",
+							"note": "",
+							"available": true,
+							"canUpdate": false
+						}
+					]
+				},
+				"PensionDeductionValue": {
+					"description": "Valor da dedução de pensão",
+					"type": "number",
+					"format": "double",
+					"x-totvs": [
+						{
+							"product": "RM",
+							"field": "PPAGTOAUTONOMOEXTDEPEND.VALORDEDUCAOPENSAO",
+							"required": false,
+							"type": "Decimal",
+							"length": "8",
+							"note": "Valor da dedução de pensão",
+							"available": true,
+							"canUpdate": false
+						},
+						{
+							"product": "PROTHEUS",
+							"field": "",
+							"required": true,
+							"type": "",
+							"length": "",
+							"note": "",
+							"available": true,
+							"canUpdate": false
+						}
+					]
+				}
+            }
+        }
+	}
+}


### PR DESCRIPTION
Ajuste de schema, remove tag InternalId, não é necessário para vinculação de dependentes de autônomos externos