### PR TITLE
ItemStructures/V1/1_002

### DIFF
--- a/jsonschema/apis/ItemStructures_v1_000.json
+++ b/jsonschema/apis/ItemStructures_v1_000.json
@@ -23,7 +23,7 @@
 					"product": "Datasul",
 					"contact": "guilherme.hoch@totvs.com.br",
 					"description": "Cadastro de Estruturas de Itens",
-					"adapter": "/totvs-rest/prg/man/v1/itemStructures.p",
+					"adapter": "/api/man/v1/itemStructures.p",
 					"helpUrl": ""
 				}
 			]
@@ -32,7 +32,7 @@
 	"servers": [
 		{
 			"description": "Documentação para API de Estrutura de Itens",
-			"url": "{{host}}/api/totvs-rest/prg/man/v1",
+			"url": "{{host}}/api/man/v1",
 			"variables": {
 				"serverUrl": {
 					"default": "localhost"

--- a/jsonschema/schemas/ItemStructures_1_002.json
+++ b/jsonschema/schemas/ItemStructures_1_002.json
@@ -23,7 +23,7 @@
 					"product": "Datasul",
 					"contact": "guilherme.hoch@totvs.com.br",
 					"description": "Cadastro de Estruturas de Itens",
-					"adapter": "/totvs-rest/prg/man/v1/itemStructures.p",
+					"adapter": "/api/man/v1/itemStructures.p",
 					"helpUrl": ""
 				}
 			]


### PR DESCRIPTION
Neste pull request, alteramos apenas o caminho na documentação da API para o novo padrão REST, visto que o contexto totvs-rest foi depreciado. Não houve alteração nenhuma na estrutura da API ou no schema em si.