### PR TITLE
feat(CCP): adiciona especificações OpenAPI/T-Talk das APIs ItemIntegrMePublic e ItemStatusIntegraPublic

### DIFF
--- a/jsonschema/apis/ItemIntegrMePublic_v1_000.json
+++ b/jsonschema/apis/ItemIntegrMePublic_v1_000.json
@@ -1,0 +1,178 @@
+{
+  "openapi": "3.0.3",
+  "info": {
+    "title": "ItemIntegrMePublic",
+    "description": "API REST para consulta de itens e atualização de status de integração do Mercado Eletrônico (ME) com ERP Datasul.",
+    "version": "1.000",
+    "x-totvs": {
+      "message": "ItemIntegrMePublic",
+      "productSegment": "ERP",
+      "contact": "mcc.support@totvs.com.br"
+    }
+  },
+  "servers": [
+    {
+      "url": "https://api.totvs.com.br/public/ccp/v1",
+      "description": "Servidor de Produção API Gateway TOTVS"
+    }
+  ],
+  "paths": {
+    "/me": {
+      "get": {
+        "summary": "Consulta/Listagem paginada de itens para o Mercado Eletrônico",
+        "description": "Retorna uma lista paginada de itens cadastrados no ERP Datasul para integração com a plataforma ME.",
+        "operationId": "getItems",
+        "parameters": [
+          {
+            "name": "page",
+            "in": "query",
+            "description": "Número da página solicitada",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "default": 1
+            }
+          },
+          {
+            "name": "pageSize",
+            "in": "query",
+            "description": "Quantidade de registros por página",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "default": 20
+            }
+          },
+          {
+            "name": "searchKeywords",
+            "in": "query",
+            "description": "Filtro por palavra-chave no código ou descrição do item",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Lista de itens retornada com sucesso",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "../schemas/ItemIntegrMePublic_1_000.json#/definitions/ItemResponseList"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Parâmetros de requisição inválidos",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "../schemas/ItemIntegrMePublic_1_000.json#/definitions/FrameworkRowErrors"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Erro interno de execução na procedure Progress ABL",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "../schemas/ItemIntegrMePublic_1_000.json#/definitions/FrameworkRowErrors"
+                }
+              }
+            }
+          }
+        }
+      },
+      "put": {
+        "summary": "Atualização ou Upsert de Status de Integração",
+        "description": "Persiste ou atualiza o status de integração do item informado pelo Mercado Eletrônico no ERP Datasul.",
+        "operationId": "updateItemStatus",
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "../schemas/ItemIntegrMePublic_1_000.json#/definitions/ItemStatus"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Status do item atualizado com sucesso",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "../schemas/ItemIntegrMePublic_1_000.json#/definitions/ItemResponseSingle"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Payload de integração inválido ou erro de validação de negócio",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "../schemas/ItemIntegrMePublic_1_000.json#/definitions/FrameworkRowErrors"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Erro ao persistir dados na tabela do Datasul",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "../schemas/ItemIntegrMePublic_1_000.json#/definitions/FrameworkRowErrors"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/me/{itemCode}": {
+      "get": {
+        "summary": "Busca detalhada de um item pelo código",
+        "description": "Retorna o objeto completo do item filtrado pelo seu código único.",
+        "operationId": "getItemByCode",
+        "parameters": [
+          {
+            "name": "itemCode",
+            "in": "path",
+            "description": "Código único do item cadastrado no ERP Datasul",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Item localizado com sucesso",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "../schemas/ItemIntegrMePublic_1_000.json#/definitions/ItemResponseSingle"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Item não encontrado",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "../schemas/ItemIntegrMePublic_1_000.json#/definitions/FrameworkRowErrors"
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/jsonschema/apis/ItemStatusIntegraPublic_v1_000.json
+++ b/jsonschema/apis/ItemStatusIntegraPublic_v1_000.json
@@ -1,0 +1,70 @@
+{
+  "openapi": "3.0.3",
+  "info": {
+    "title": "ItemStatusIntegraPublic",
+    "description": "API REST para atualização de status e acompanhamento de integração de itens com o Mercado Eletrônico (ME) no ERP Datasul.",
+    "version": "1.000",
+    "x-totvs": {
+      "message": "ItemStatusIntegraPublic",
+      "productSegment": "ERP",
+      "contact": "mcc.support@totvs.com.br"
+    }
+  },
+  "servers": [
+    {
+      "url": "https://api.totvs.com.br/public/ccp/v1",
+      "description": "Servidor de Produção API Gateway TOTVS"
+    }
+  ],
+  "paths": {
+    "/status": {
+      "put": {
+        "summary": "Atualização de Status de Integração",
+        "description": "Persiste ou atualiza o status do processamento da integração de itens via código (`itemCode`) ou identificador de correlação (`correlationId`).",
+        "operationId": "updateItemIntegrationStatus",
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "../schemas/ItemStatusIntegraPublic_1_000.json#/definitions/ItemStatusRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Status do item atualizado com sucesso no Datasul",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "../schemas/ItemStatusIntegraPublic_1_000.json#/definitions/ItemStatusResponseSingle"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Payload de integração com estrutura ou campos inválidos",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "../schemas/ItemStatusIntegraPublic_1_000.json#/definitions/FrameworkRowErrors"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Erro de execução ou persistência na procedure Progress ABL",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "../schemas/ItemStatusIntegraPublic_1_000.json#/definitions/FrameworkRowErrors"
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/jsonschema/schemas/ItemIntegrMePublic_1_000.json
+++ b/jsonschema/schemas/ItemIntegrMePublic_1_000.json
@@ -1,0 +1,135 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "title": "ItemIntegrMePublic",
+  "description": "Schemas de dados para integração de itens e status com o Mercado Eletrônico (ME)",
+  "type": "object",
+  "definitions": {
+    "Item": {
+      "type": "object",
+      "properties": {
+        "itemCode": {
+          "type": "string",
+          "description": "Código do item no ERP Datasul",
+          "example": "ITEM-001"
+        },
+        "description": {
+          "type": "string",
+          "description": "Descrição detalhada do item",
+          "example": "PARAFUSO SEXTAVADO AÇO INOX 1/2"
+        },
+        "unitOfMeasure": {
+          "type": "string",
+          "description": "Unidade de medida principal",
+          "example": "UN"
+        },
+        "nbmCode": {
+          "type": "string",
+          "description": "Código NCM/NBM fiscal do item",
+          "example": "73181500"
+        },
+        "itemOrigin": {
+          "type": "integer",
+          "description": "Origem do material (0-Nacional, 1-Estrangeira, etc.)",
+          "example": 0
+        },
+        "controlType": {
+          "type": "integer",
+          "description": "Tipo de controle de estoque (1-Físico, 2-Total, 3-Consignado)",
+          "example": 1
+        },
+        "estimatedPrice": {
+          "type": "number",
+          "format": "double",
+          "description": "Preço unitário estimado do item",
+          "example": 15.50
+        },
+        "businessOrganization": {
+          "type": "string",
+          "description": "Código do estabelecimento/empresa vinculada",
+          "example": "101"
+        },
+        "_expandables": {
+          "type": "array",
+          "description": "Propriedades expansíveis injetadas no objeto",
+          "items": {
+            "type": "string"
+          },
+          "example": ["narrative", "family"]
+        }
+      },
+      "required": ["itemCode", "description", "unitOfMeasure"]
+    },
+    "ItemStatus": {
+      "type": "object",
+      "properties": {
+        "itemCode": {
+          "type": "string",
+          "description": "Código do item a ser atualizado",
+          "example": "ITEM-001"
+        },
+        "integrationStatus": {
+          "type": "string",
+          "enum": ["PENDING", "SUCCESS", "ERROR"],
+          "description": "Status do processamento de integração",
+          "example": "SUCCESS"
+        },
+        "errorMessage": {
+          "type": "string",
+          "description": "Mensagem detalhada em caso de erro na integração",
+          "example": ""
+        },
+        "lastUpdate": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Data e hora do processamento do status",
+          "example": "2026-07-20T10:18:40Z"
+        }
+      },
+      "required": ["itemCode", "integrationStatus"]
+    },
+    "ItemResponseList": {
+      "type": "object",
+      "properties": {
+        "payload": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/Item"
+          }
+        },
+        "hasNext": {
+          "type": "boolean",
+          "description": "Indica se existem mais registros nas próximas páginas",
+          "example": false
+        }
+      }
+    },
+    "ItemResponseSingle": {
+      "type": "object",
+      "properties": {
+        "payload": {
+          "$ref": "#/definitions/Item"
+        }
+      }
+    },
+    "FrameworkRowErrors": {
+      "type": "object",
+      "properties": {
+        "code": {
+          "type": "string",
+          "description": "Código identificador do erro",
+          "example": "ERR-ME-001"
+        },
+        "message": {
+          "type": "string",
+          "description": "Descrição resumida da ocorrência",
+          "example": "Item informado não foi localizado no Datasul."
+        },
+        "detailedMessage": {
+          "type": "string",
+          "description": "Detalhes adicionais para resolução do erro",
+          "example": "Verifique se a chave informada existe na tabela item."
+        }
+      }
+    }
+  }
+}

--- a/jsonschema/schemas/ItemStatusIntegraPublic_1_000.json
+++ b/jsonschema/schemas/ItemStatusIntegraPublic_1_000.json
@@ -1,0 +1,69 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "title": "ItemStatusIntegraPublic",
+  "description": "Schema de dados para atualização de status de integração de itens com o Mercado Eletrônico",
+  "type": "object",
+  "definitions": {
+    "ItemStatusRequest": {
+      "type": "object",
+      "properties": {
+        "itemCode": {
+          "type": "string",
+          "description": "Código do item no ERP Datasul",
+          "example": "ITEM-001"
+        },
+        "correlationId": {
+          "type": "string",
+          "description": "Identificador único de correlação do processo de integração",
+          "example": "550e8400-e29b-41d4-a716-446655440000"
+        },
+        "integrationStatus": {
+          "type": "string",
+          "enum": ["PENDING", "SUCCESS", "ERROR"],
+          "description": "Status do processamento retornado pelo Mercado Eletrônico",
+          "example": "SUCCESS"
+        },
+        "errorMessage": {
+          "type": "string",
+          "description": "Mensagem detalhada em caso de erro na integração",
+          "example": ""
+        },
+        "lastUpdate": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Data e hora do processamento",
+          "example": "2026-07-20T10:18:40Z"
+        }
+      },
+      "required": ["integrationStatus"]
+    },
+    "ItemStatusResponseSingle": {
+      "type": "object",
+      "properties": {
+        "payload": {
+          "$ref": "#/definitions/ItemStatusRequest"
+        }
+      }
+    },
+    "FrameworkRowErrors": {
+      "type": "object",
+      "properties": {
+        "code": {
+          "type": "string",
+          "description": "Código identificador da ocorrência de erro",
+          "example": "ERR-STATUS-001"
+        },
+        "message": {
+          "type": "string",
+          "description": "Mensagem resumida do erro",
+          "example": "Chave de identificação não encontrada."
+        },
+        "detailedMessage": {
+          "type": "string",
+          "description": "Detalhes técnicos para resolução do erro na ABL",
+          "example": "Nem o itemCode nem o correlationId informados foram localizados na base de dados."
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Descrição das Alterações
Inclusão dos contratos OpenAPI 3.0 / T-Talk referentes ao produto Datasul (Módulo CCP).

### APIs Incluídas:
1. **ItemIntegrMePublic**
   - Rota: `jsonschema/apis/ItemIntegrMePublic_v1_000.json`
   - Schema: `jsonschema/schemas/ItemIntegrMePublic_1_000.json`

2. **ItemStatusIntegraPublic**
   - Rota: `jsonschema/apis/ItemStatusIntegraPublic_v1_000.json`
   - Schema: `jsonschema/schemas/ItemStatusIntegraPublic_1_000.json`

### Tarefa / Issue Relacionada:
- **Jira:** DBACKSUPDTS-766

### Checklist de Governança:
- [x] Estruturas JSON separadas nas pastas correspondentes (`/apis` e `/schemas`).
- [x] Nomenclaturas em formato `UpperCamelCase` com versionamento explicito `_v1_000` / `_1_000`.
- [x] Contratos OpenAPI 3.0 validados localmente.
- [x] Referências cruzadas (`$ref`) apontando para os schemas correspondentes.